### PR TITLE
refactor(buffer): remove stale #[allow(dead_code)] suppressions

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -127,7 +127,7 @@ unsafe extern "C" fn dlmanaged_deleter(ptr: *mut DLManagedTensor) {
 // ─── RawBuffer ────────────────────────────────────────────────────────────────
 
 /// The source of a `RawBuffer`'s backing bytes.
-#[allow(dead_code)]
+
 enum BufferSource {
     /// Memory owned by mohu's allocator.
     Owned(AllocHandle),

--- a/crates/mohu-buffer/src/pool.rs
+++ b/crates/mohu-buffer/src/pool.rs
@@ -107,12 +107,6 @@ impl PoolBucket {
         Some(h)
     }
 
-    #[allow(dead_code)]
-    fn clear(&mut self) {
-        self.handles.clear();
-        self.cached_bytes = 0;
-    }
-
     fn len(&self) -> usize { self.handles.len() }
 }
 


### PR DESCRIPTION
Closes #2

## Changes

### `src/buffer.rs` — remove stale attribute on `BufferSource`
Both variants (`Owned` and `DLPack`) are actively constructed and
matched throughout the file. The suppression predates the DLPack
implementation and was never removed.

### `src/pool.rs` — remove unused `PoolBucket::clear()`
The method had no callers. `BufferPool::clear()` releases memory by
calling `inner.buckets.clear()`, which drops the entire Vec<PoolBucket>.
Removing it is cleaner than silencing the warning.

## Testing
`cargo clippy --all-targets --all-features` — no dead_code warnings for these items.