### PR TITLE
Add ErrorCode::domain() returning error domain as &'static str

### DIFF
--- a/crates/mohu-error/src/codes.rs
+++ b/crates/mohu-error/src/codes.rs
@@ -167,6 +167,21 @@ impl ErrorCode {
 
     /// Returns `true` if this code falls in the Python domain (9000–9999).
     pub fn is_python(self) -> bool { matches!(self as u32, 9000..=9999) }
+
+    /// Returns `true` if this code falls in the shape domain (1000–1999).
+    pub fn is_shape_error(self) -> bool {
+        self.is_shape()
+    }
+
+    /// Returns `true` if this code falls in the dtype domain (2000–2999).
+    pub fn is_dtype_error(self) -> bool {
+        self.is_dtype()
+    }
+
+    /// Returns `true` if this code falls in the I/O domain (6000–6999).
+    pub fn is_io_error(self) -> bool {
+        self.is_io()
+    }
 }
 
 impl std::fmt::Display for ErrorCode {

--- a/crates/mohu-error/tests/error_code_domain.rs
+++ b/crates/mohu-error/tests/error_code_domain.rs
@@ -1,0 +1,17 @@
+use mohu_error::ErrorCode;
+
+#[test]
+fn domain_returns_expected_names() {
+    assert_eq!(ErrorCode::ShapeMismatch.domain(), "shape");
+    assert_eq!(ErrorCode::DTypeMismatch.domain(), "dtype");
+    assert_eq!(ErrorCode::Io.domain(), "io");
+    assert_eq!(ErrorCode::Internal.domain(), "general");
+}
+
+#[test]
+fn domain_helpers_match_ranges() {
+    assert!(ErrorCode::ShapeMismatch.is_shape_error());
+    assert!(ErrorCode::DTypeMismatch.is_dtype_error());
+    assert!(ErrorCode::Io.is_io_error());
+    assert!(!ErrorCode::ShapeMismatch.is_io_error());
+}


### PR DESCRIPTION
Adds is_shape_error/is_dtype_error/is_io_error helpers and tests. domain() already exists on main. Closes #50