### PR TITLE
Implement TryFrom<u32> and Display for ErrorCode

### DIFF
--- a/crates/mohu-error/src/codes.rs
+++ b/crates/mohu-error/src/codes.rs
@@ -169,6 +169,13 @@ impl ErrorCode {
     pub fn is_python(self) -> bool { matches!(self as u32, 9000..=9999) }
 }
 
+
+impl From<ErrorCode> for u32 {
+    fn from(code: ErrorCode) -> u32 {
+        code as u32
+    }
+}
+
 impl TryFrom<u32> for ErrorCode {
     type Error = ();
 

--- a/crates/mohu-error/src/codes.rs
+++ b/crates/mohu-error/src/codes.rs
@@ -169,8 +169,86 @@ impl ErrorCode {
     pub fn is_python(self) -> bool { matches!(self as u32, 9000..=9999) }
 }
 
+impl TryFrom<u32> for ErrorCode {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            1000 => Ok(Self::ShapeMismatch),
+            1001 => Ok(Self::BroadcastError),
+            1002 => Ok(Self::DimensionMismatch),
+            1003 => Ok(Self::AxisOutOfRange),
+            1004 => Ok(Self::ScalarArray),
+            1005 => Ok(Self::ZeroSizedDimension),
+            1006 => Ok(Self::ShapeOverflow),
+            1007 => Ok(Self::ReshapeIncompatible),
+            1008 => Ok(Self::EmptyStackSequence),
+            1009 => Ok(Self::ConcatShapeMismatch),
+            2000 => Ok(Self::DTypeMismatch),
+            2001 => Ok(Self::InvalidCast),
+            2002 => Ok(Self::Overflow),
+            2003 => Ok(Self::Underflow),
+            2004 => Ok(Self::UnknownDType),
+            2005 => Ok(Self::UnsupportedDType),
+            2006 => Ok(Self::AmbiguousPromotion),
+            3000 => Ok(Self::IndexOutOfBounds),
+            3001 => Ok(Self::TooManyIndices),
+            3002 => Ok(Self::ZeroSliceStep),
+            3003 => Ok(Self::SliceOutOfBounds),
+            3004 => Ok(Self::BoolIndexShapeMismatch),
+            3005 => Ok(Self::FancyIndexOutOfBounds),
+            4000 => Ok(Self::AllocationFailed),
+            4001 => Ok(Self::AlignmentError),
+            4002 => Ok(Self::BufferTooSmall),
+            4003 => Ok(Self::InvalidStride),
+            4004 => Ok(Self::OverlappingStrides),
+            4005 => Ok(Self::NonContiguous),
+            4006 => Ok(Self::ReadOnly),
+            4007 => Ok(Self::CannotResizeShared),
+            4008 => Ok(Self::OffsetOverflow),
+            5000 => Ok(Self::SingularMatrix),
+            5001 => Ok(Self::NonConvergence),
+            5002 => Ok(Self::DomainError),
+            5003 => Ok(Self::DivisionByZero),
+            5004 => Ok(Self::MatrixDimensionMismatch),
+            5005 => Ok(Self::EigenDecompositionFailed),
+            5006 => Ok(Self::NotPositiveDefinite),
+            5007 => Ok(Self::QRRankDeficient),
+            5008 => Ok(Self::SVDNonConvergence),
+            5009 => Ok(Self::UnsupportedNormOrder),
+            6000 => Ok(Self::Io),
+            6001 => Ok(Self::InvalidMagic),
+            6002 => Ok(Self::UnsupportedVersion),
+            6003 => Ok(Self::CorruptData),
+            6004 => Ok(Self::UnexpectedEof),
+            6005 => Ok(Self::UnsupportedCodec),
+            6006 => Ok(Self::NpyHeaderError),
+            6007 => Ok(Self::NpzEntryNotFound),
+            6008 => Ok(Self::CsvParseError),
+            7000 => Ok(Self::DLPackUnsupportedDevice),
+            7001 => Ok(Self::DLPackVersionMismatch),
+            7002 => Ok(Self::DLPackNullPointer),
+            7003 => Ok(Self::DLPackUnsupportedDType),
+            7004 => Ok(Self::DLPackInvalid),
+            8000 => Ok(Self::ArrowSchema),
+            8001 => Ok(Self::ArrowIpc),
+            8002 => Ok(Self::ArrowUnsupportedType),
+            8003 => Ok(Self::ArrowValidityError),
+            9000 => Ok(Self::PythonType),
+            9001 => Ok(Self::PythonValue),
+            9002 => Ok(Self::PythonBuffer),
+            9003 => Ok(Self::PythonNoBuffer),
+            9004 => Ok(Self::PythonUnsupportedBufferFormat),
+            10000 => Ok(Self::Context),
+            10001 => Ok(Self::NotImplemented),
+            10002 => Ok(Self::Internal),
+            _ => Err(()),
+        }
+    }
+}
+
 impl std::fmt::Display for ErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "E{:04}", *self as u32)
+        write!(f, "{self:?} ({})", *self as u32)
     }
 }

--- a/crates/mohu-error/tests/codes_tests.rs
+++ b/crates/mohu-error/tests/codes_tests.rs
@@ -18,3 +18,9 @@ fn display_includes_variant_and_number() {
     let code = ErrorCode::ShapeMismatch;
     assert_eq!(format!("{code}"), "ShapeMismatch (1000)");
 }
+
+#[test]
+fn from_u32_roundtrip() {
+    let code = ErrorCode::ShapeMismatch;
+    assert_eq!(u32::from(code), 1000);
+}

--- a/crates/mohu-error/tests/codes_tests.rs
+++ b/crates/mohu-error/tests/codes_tests.rs
@@ -1,0 +1,20 @@
+use mohu_error::ErrorCode;
+
+#[test]
+fn try_from_known_codes() {
+    let code = ErrorCode::try_from(1000u32).unwrap();
+    assert_eq!(code, ErrorCode::ShapeMismatch);
+    assert_eq!(ErrorCode::try_from(10002u32).unwrap(), ErrorCode::Internal);
+}
+
+#[test]
+fn try_from_rejects_unknown_codes() {
+    assert!(ErrorCode::try_from(999u32).is_err());
+    assert!(ErrorCode::try_from(1500u32).is_err());
+}
+
+#[test]
+fn display_includes_variant_and_number() {
+    let code = ErrorCode::ShapeMismatch;
+    assert_eq!(format!("{code}"), "ShapeMismatch (1000)");
+}


### PR DESCRIPTION
Adds TryFrom<u32> for all stable codes, updates Display to `VariantName (NNNN)`, and integration tests. Closes #49