### PR TITLE
Feat/buffer is square

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -561,7 +561,10 @@ impl Buffer {
     pub fn is_aligned(&self)       -> bool { self.flags.contains(BufferFlags::ALIGNED) }
     /// Returns `true` if the backing memory is shared with other `Buffer` instances.
     pub fn is_shared(&self)        -> bool { Arc::strong_count(&self.raw) > 1 }
-
+    /// Returns `true` if this buffer is a square 2-D matrix.
+    #[must_use]
+    pub fn is_square(&self)        -> bool { self.ndim() == 2 && self.shape()[0] == self.shape()[1] }
+    
     /// Returns a raw const pointer to element `[0, 0, …, 0]`.
     #[inline]
     pub fn as_ptr(&self) -> *const u8 {

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -279,3 +279,22 @@ fn nd_index_iter_c_order() {
     assert_eq!(indices[3].as_slice(), &[1, 0]);
     assert_eq!(indices[5].as_slice(), &[1, 2]);
 }
+
+#[test]
+fn test_is_square() {
+    let sq = Buffer::from_slice_2d(&[
+        &[1.0f64, 2.0, 3.0],
+        &[4.0, 5.0, 6.0],
+        &[7.0, 8.0, 9.0],
+    ]).unwrap();
+    assert!(sq.is_square());
+
+    let rect = Buffer::from_slice_2d(&[
+        &[1.0f64, 2.0, 3.0, 4.0],
+        &[5.0, 6.0, 7.0, 8.0],
+    ]).unwrap();
+    assert!(!rect.is_square());
+
+    let flat = Buffer::from_slice(&[1.0f64, 2.0, 3.0]).unwrap();
+    assert!(!flat.is_square());
+}


### PR DESCRIPTION
## What

Resolves #37 
Adds `Buffer::is_square()` as a convenience method on the `Buffer` type in `mohu-buffer`.

## Why

Several operations (`tril`, `triu`, `diag`) only make sense on square matrices. Currently callers have to write:

```rust
buf.ndim() == 2 && buf.shape()[0] == buf.shape()[1]
```

This PR wraps that check into a clean, reusable method. Closes #37

## How

Added `is_square()` in the Properties section of `buffer.rs`, alongside `is_empty()`, `is_writeable()`, etc.:

```rust
/// Returns `true` if this buffer is a square 2-D matrix.
#[must_use]
pub fn is_square(&self) -> bool { self.ndim() == 2 && self.shape()[0] == self.shape()[1] }
```

Also added a test in `tests/integration.rs` covering square, non-square, and 1-D cases.

## Checklist

- [x] `cargo test -p mohu-buffer` passes (28/28 tests)
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all` applied
- [ ] `CHANGELOG.md` updated (if user-facing change)
- [ ] Benchmarks added or updated (if performance-sensitive path)