### PR TITLE
Add proptest strategies for DType to mohu-testing

### DIFF
--- a/crates/mohu-testing/src/strategies.rs
+++ b/crates/mohu-testing/src/strategies.rs
@@ -1,1 +1,37 @@
-// gen — implementation pending
+//! Proptest strategies for mohu types.
+
+use mohu_dtype::{DType, ALL_DTYPES};
+use proptest::prelude::*;
+
+const FLOAT_DTYPES: &[DType] = &[DType::F16, DType::BF16, DType::F32, DType::F64];
+const INTEGER_DTYPES: &[DType] = &[
+    DType::I8,
+    DType::I16,
+    DType::I32,
+    DType::I64,
+    DType::U8,
+    DType::U16,
+    DType::U32,
+    DType::U64,
+];
+const STANDARD_FLOAT_DTYPES: &[DType] = &[DType::F32, DType::F64];
+
+/// Arbitrary [`DType`] from all supported variants.
+pub fn arb_dtype() -> impl Strategy<Value = DType> {
+    prop::sample::select(ALL_DTYPES.as_slice())
+}
+
+/// Arbitrary floating-point [`DType`] (F16, BF16, F32, F64).
+pub fn arb_float_dtype() -> impl Strategy<Value = DType> {
+    prop::sample::select(FLOAT_DTYPES)
+}
+
+/// Arbitrary integer [`DType`] (signed and unsigned, I8–U64).
+pub fn arb_integer_dtype() -> impl Strategy<Value = DType> {
+    prop::sample::select(INTEGER_DTYPES)
+}
+
+/// Arbitrary standard IEEE float [`DType`] (F32 or F64 only).
+pub fn arb_standard_float_dtype() -> impl Strategy<Value = DType> {
+    prop::sample::select(STANDARD_FLOAT_DTYPES)
+}

--- a/crates/mohu-testing/tests/dtype_strategies.rs
+++ b/crates/mohu-testing/tests/dtype_strategies.rs
@@ -1,0 +1,27 @@
+use mohu_dtype::{DType, ALL_DTYPES};
+use mohu_testing::strategies::{
+    arb_dtype, arb_float_dtype, arb_integer_dtype, arb_standard_float_dtype,
+};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn arb_dtype_is_known_variant(dtype in arb_dtype()) {
+        prop_assert!(ALL_DTYPES.contains(&dtype));
+    }
+
+    #[test]
+    fn arb_float_dtype_yields_float(dtype in arb_float_dtype()) {
+        prop_assert!(dtype.is_float());
+    }
+
+    #[test]
+    fn arb_integer_dtype_yields_integer(dtype in arb_integer_dtype()) {
+        prop_assert!(dtype.is_integer());
+    }
+
+    #[test]
+    fn arb_standard_float_dtype_yields_f32_or_f64(dtype in arb_standard_float_dtype()) {
+        prop_assert!(matches!(dtype, DType::F32 | DType::F64));
+    }
+}


### PR DESCRIPTION
Adds arb_dtype, arb_float_dtype, arb_integer_dtype, arb_standard_float_dtype and property tests. Closes #58