### PR TITLE
Add SliceArg::from_range constructor for std::ops::Range

### DIFF
--- a/crates/mohu-buffer/src/layout.rs
+++ b/crates/mohu-buffer/src/layout.rs
@@ -45,6 +45,22 @@ pub struct SliceArg {
     pub step:  Option<i64>,
 }
 
+impl From<std::ops::Range<usize>> for SliceArg {
+    fn from(range: std::ops::Range<usize>) -> Self {
+        Self {
+            start: Some(range.start as i64),
+            stop: Some(range.end as i64),
+            step: None,
+        }
+    }
+}
+
+impl From<std::ops::RangeFull> for SliceArg {
+    fn from(_: std::ops::RangeFull) -> Self {
+        Self::FULL
+    }
+}
+
 impl SliceArg {
     /// A slice that selects the full axis (`..`).
     pub const FULL: Self = Self { start: None, stop: None, step: None };

--- a/crates/mohu-buffer/tests/slice_arg.rs
+++ b/crates/mohu-buffer/tests/slice_arg.rs
@@ -1,0 +1,21 @@
+use mohu_buffer::SliceArg;
+
+#[test]
+fn from_usize_range() {
+    let arg: SliceArg = (2..5).into();
+    assert_eq!(arg.start, Some(2));
+    assert_eq!(arg.stop, Some(5));
+    assert_eq!(arg.step, None);
+
+    let (start, count, step) = arg.resolve(10).unwrap();
+    assert_eq!((start, count, step), (2, 3, 1));
+}
+
+#[test]
+fn from_range_full() {
+    let arg: SliceArg = (..).into();
+    assert_eq!(arg, SliceArg::FULL);
+
+    let (start, count, step) = arg.resolve(8).unwrap();
+    assert_eq!((start, count, step), (0, 8, 1));
+}


### PR DESCRIPTION
Implements From<Range<usize>> and From<RangeFull> for SliceArg with integration tests. Closes #41