### PR TITLE
Add Buffer::shape_matches() helper to reduce precondition boilerplate

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -532,6 +532,22 @@ impl Buffer {
     #[inline] pub fn layout(&self)   -> &Layout { &self.layout }
     /// Returns the shape of this buffer as a slice of dimension sizes.
     #[inline] pub fn shape(&self)    -> &[usize] { self.layout.shape() }
+
+    /// Returns `Ok(())` when `self` and `other` have the same shape.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MohuError::ShapeMismatch`] when shapes differ.
+    pub fn shape_matches(&self, other: &Buffer) -> MohuResult<()> {
+        if self.shape() != other.shape() {
+            return Err(MohuError::ShapeMismatch {
+                expected: self.shape().to_vec(),
+                got:      other.shape().to_vec(),
+            });
+        }
+        Ok(())
+    }
+
     /// Returns the byte strides of this buffer.
     #[inline] pub fn strides(&self)  -> &[isize] { self.layout.strides() }
     /// Returns the number of dimensions (axes) of this buffer.
@@ -561,6 +577,26 @@ impl Buffer {
     pub fn is_aligned(&self)       -> bool { self.flags.contains(BufferFlags::ALIGNED) }
     /// Returns `true` if the backing memory is shared with other `Buffer` instances.
     pub fn is_shared(&self)        -> bool { Arc::strong_count(&self.raw) > 1 }
+
+    /// Returns `true` if the buffer is 2D and both dimensions are equal.
+    pub fn is_square(&self) -> bool {
+        self.ndim() == 2 && self.shape()[0] == self.shape()[1]
+    }
+
+    /// Returns `true` if the buffer is 1D (a vector).
+    pub fn is_vector(&self) -> bool {
+        self.ndim() == 1
+    }
+
+    /// Returns `true` if the buffer is 2D (a matrix).
+    pub fn is_matrix(&self) -> bool {
+        self.ndim() == 2
+    }
+
+    /// Returns `true` if the buffer is 0D (a scalar — shape `[]`).
+    pub fn is_scalar_shape(&self) -> bool {
+        self.ndim() == 0
+    }
 
     /// Returns a raw const pointer to element `[0, 0, …, 0]`.
     #[inline]

--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -160,12 +160,7 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
             got:      dst.dtype().to_string(),
         });
     }
-    if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
-        });
-    }
+    src.shape_matches(dst)?;
     if !dst.is_writeable() {
         return Err(MohuError::ReadOnly);
     }
@@ -214,12 +209,7 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
 /// pairs with zero virtual dispatch.  For the identity cast (same dtype),
 /// delegates to `copy_to_contiguous`.
 pub fn cast_copy(src: &Buffer, dst: &mut Buffer, mode: CastMode) -> MohuResult<()> {
-    if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
-        });
-    }
+    src.shape_matches(dst)?;
     if src.dtype() == dst.dtype() {
         return copy_to_contiguous(src, dst);
     }
@@ -305,12 +295,7 @@ where
     if !src.is_c_contiguous() || !dst.is_c_contiguous() {
         return Err(MohuError::NonContiguous);
     }
-    if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
-        });
-    }
+    src.shape_matches(dst)?;
     if !dst.is_writeable() {
         return Err(MohuError::ReadOnly);
     }
@@ -466,12 +451,7 @@ where
             got:      src.dtype().to_string(),
         });
     }
-    if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
-        });
-    }
+    src.shape_matches(dst)?;
     if !src.is_c_contiguous() || !dst.is_c_contiguous() {
         return Err(MohuError::NonContiguous);
     }
@@ -554,24 +534,14 @@ pub fn where_select<T: Scalar + Copy + Send + Sync>(
                 got:      buf.dtype().to_string(),
             });
         }
-        if buf.shape() != mask.shape() {
-            return Err(MohuError::ShapeMismatch {
-                expected: mask.shape().to_vec(),
-                got:      buf.shape().to_vec(),
-            });
-        }
+        mask.shape_matches(buf)?;
         if !buf.is_c_contiguous() {
             let _ = name;
             return Err(MohuError::NonContiguous);
         }
     }
     if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
-    if dst.shape() != mask.shape() {
-        return Err(MohuError::ShapeMismatch {
-            expected: mask.shape().to_vec(),
-            got:      dst.shape().to_vec(),
-        });
-    }
+    mask.shape_matches(dst)?;
     dst.make_unique()?;
 
     let len    = mask.len();
@@ -611,12 +581,7 @@ where
             got:      src.dtype().to_string(),
         });
     }
-    if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
-        });
-    }
+    src.shape_matches(dst)?;
     if !src.is_c_contiguous() || !dst.is_c_contiguous() {
         return Err(MohuError::NonContiguous);
     }
@@ -660,12 +625,7 @@ pub fn gather(src: &Buffer, indices: &Buffer, dst: &mut Buffer) -> MohuResult<()
     if !src.is_c_contiguous() || !indices.is_c_contiguous() || !dst.is_c_contiguous() {
         return Err(MohuError::NonContiguous);
     }
-    if indices.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
-            expected: indices.shape().to_vec(),
-            got:      dst.shape().to_vec(),
-        });
-    }
+    indices.shape_matches(dst)?;
     if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
     dst.make_unique()?;
 
@@ -727,12 +687,7 @@ pub fn scatter(dst: &mut Buffer, indices: &Buffer, src: &Buffer) -> MohuResult<(
     if !src.is_c_contiguous() || !indices.is_c_contiguous() || !dst.is_c_contiguous() {
         return Err(MohuError::NonContiguous);
     }
-    if indices.len() != src.len() {
-        return Err(MohuError::ShapeMismatch {
-            expected: indices.shape().to_vec(),
-            got:      src.shape().to_vec(),
-        });
-    }
+    indices.shape_matches(src)?;
     if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
     dst.make_unique()?;
 
@@ -947,12 +902,7 @@ pub fn flip_axis_copy(src: &Buffer, dst: &mut Buffer, axis: usize) -> MohuResult
             got:      dst.dtype().to_string(),
         });
     }
-    if src.shape() != dst.shape() {
-        return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
-        });
-    }
+    src.shape_matches(dst)?;
     if axis >= src.ndim() {
         return Err(MohuError::bug(format!(
             "flip_axis_copy: axis {axis} out of bounds for ndim {}", src.ndim()
@@ -1373,12 +1323,8 @@ where
             got:      a.dtype().to_string(),
         });
     }
-    if a.len() != b.len() || a.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
-            expected: a.shape().to_vec(),
-            got:      b.shape().to_vec(),
-        });
-    }
+    a.shape_matches(b)?;
+    a.shape_matches(dst)?;
     if !a.is_c_contiguous() || !b.is_c_contiguous() || !dst.is_c_contiguous() {
         return Err(MohuError::NonContiguous);
     }

--- a/crates/mohu-buffer/tests/shape_matches.rs
+++ b/crates/mohu-buffer/tests/shape_matches.rs
@@ -1,0 +1,25 @@
+use mohu_buffer::Buffer;
+use mohu_dtype::DType;
+use mohu_error::{MohuError, MohuResult};
+
+#[test]
+fn shape_matches_succeeds_for_equal_shapes() -> MohuResult<()> {
+    let a = Buffer::zeros(DType::F64, &[2, 3])?;
+    let b = Buffer::zeros(DType::F32, &[2, 3])?;
+    a.shape_matches(&b)
+}
+
+#[test]
+fn shape_matches_returns_shape_mismatch() {
+    let a = Buffer::zeros(DType::F64, &[2, 3]).unwrap();
+    let b = Buffer::zeros(DType::F64, &[3, 2]).unwrap();
+
+    let err = a.shape_matches(&b).unwrap_err();
+    match err {
+        MohuError::ShapeMismatch { expected, got } => {
+            assert_eq!(expected, vec![2, 3]);
+            assert_eq!(got, vec![3, 2]);
+        }
+        other => panic!("expected ShapeMismatch, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Adds shape_matches() and replaces repeated shape checks in ops.rs. Closes #43