### PR TITLE
Implement Default for Order (returns Order::C)

### DIFF
--- a/crates/mohu-buffer/src/layout.rs
+++ b/crates/mohu-buffer/src/layout.rs
@@ -31,6 +31,12 @@ pub enum Order {
     F,
 }
 
+impl Default for Order {
+    fn default() -> Self {
+        Self::C
+    }
+}
+
 // ─── SliceArg ────────────────────────────────────────────────────────────────
 
 /// Arguments for slicing a single axis: `start:stop:step`.

--- a/crates/mohu-buffer/tests/order_default.rs
+++ b/crates/mohu-buffer/tests/order_default.rs
@@ -1,0 +1,6 @@
+use mohu_buffer::layout::Order;
+
+#[test]
+fn order_default_is_c() {
+    assert_eq!(Order::default(), Order::C);
+}


### PR DESCRIPTION
Adds Default impl for Order and a unit test. Closes #38