### PR TITLE
Add Buffer::item() to extract a scalar from a single-element array

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -639,6 +639,18 @@ impl Buffer {
         Ok(unsafe { ptr.read_unaligned() })
     }
 
+    /// Returns the sole element when this buffer contains exactly one value.
+    ///
+    /// Equivalent to NumPy's `.item()` for 0-D arrays and length-1 views.
+    #[must_use]
+    pub fn item<T: Scalar>(&self) -> MohuResult<T> {
+        if self.len() != 1 {
+            return Err(MohuError::bug("item() requires a single-element array"));
+        }
+        let indices = vec![0; self.ndim()];
+        self.get::<T>(&indices)
+    }
+
     /// Sets the element at `indices` to `value`.
     pub fn set<T: Scalar>(&mut self, indices: &[usize], value: T) -> MohuResult<()> {
         if T::DTYPE != self.dtype {

--- a/crates/mohu-buffer/tests/item.rs
+++ b/crates/mohu-buffer/tests/item.rs
@@ -1,0 +1,22 @@
+use mohu_buffer::Buffer;
+use mohu_dtype::DType;
+use mohu_error::MohuError;
+
+#[test]
+fn item_extracts_scalar_from_length_one_buffer() {
+    let buf = Buffer::from_slice::<f64>(&[42.0]).unwrap();
+    assert_eq!(buf.item::<f64>().unwrap(), 42.0);
+}
+
+#[test]
+fn item_extracts_from_zero_d_scalar() {
+    let mut buf = Buffer::zeros(DType::I32, &[]).unwrap();
+    buf.set::<i32>(&[], 7).unwrap();
+    assert_eq!(buf.item::<i32>().unwrap(), 7);
+}
+
+#[test]
+fn item_rejects_multi_element_buffer() {
+    let buf = Buffer::zeros(DType::F32, &[2]).unwrap();
+    assert!(matches!(buf.item::<f32>(), Err(MohuError::Internal(_))));
+}


### PR DESCRIPTION
Adds Buffer::item() with tests for 1-D, 0-D, and multi-element error cases. Closes #40