### PR TITLE
Buffer::allclose returns false on shape mismatch instead of broadcasting

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -1546,11 +1546,11 @@ impl Buffer {
     ///
     /// NaN == NaN for this comparison (unlike IEEE 754).
     pub fn allclose(&self, other: &Buffer, rtol: f64, atol: f64) -> MohuResult<bool> {
-        if self.shape() != other.shape() {
-            return Ok(false);
-        }
-        let a = self.cast(DType::F64, CastMode::Unsafe)?;
-        let b = other.cast(DType::F64, CastMode::Unsafe)?;
+        let shape = crate::strides::broadcast_shapes(self.shape(), other.shape())?;
+        let a = self.broadcast_to(&shape)?;
+        let b = other.broadcast_to(&shape)?;
+        let a = a.cast(DType::F64, CastMode::Unsafe)?;
+        let b = b.cast(DType::F64, CastMode::Unsafe)?;
         let as_ = a.as_slice::<f64>()?;
         let bs  = b.as_slice::<f64>()?;
         use rayon::prelude::*;

--- a/crates/mohu-buffer/src/strides.rs
+++ b/crates/mohu-buffer/src/strides.rs
@@ -102,6 +102,37 @@ pub fn contiguous_nbytes(shape: &[usize], itemsize: usize) -> MohuResult<usize> 
 /// 3. For source dimensions of size 1, the stride is set to 0 (broadcast).
 /// 4. Dimensions where both source and target are > 1 must be equal.
 ///
+/// Returns the shape that results from broadcasting `lhs` and `rhs` together.
+///
+/// Follows NumPy trailing-axis broadcast rules.
+pub fn broadcast_shapes(lhs: &[usize], rhs: &[usize]) -> MohuResult<ShapeVec> {
+    let ndim = lhs.len().max(rhs.len());
+    let mut out = ShapeVec::with_capacity(ndim);
+    for axis in 0..ndim {
+        let l = lhs
+            .get(lhs.len().wrapping_sub(ndim - axis))
+            .copied()
+            .unwrap_or(1);
+        let r = rhs
+            .get(rhs.len().wrapping_sub(ndim - axis))
+            .copied()
+            .unwrap_or(1);
+        if l == r {
+            out.push(l);
+        } else if l == 1 {
+            out.push(r);
+        } else if r == 1 {
+            out.push(l);
+        } else {
+            return Err(MohuError::BroadcastError {
+                lhs: lhs.to_vec(),
+                rhs: rhs.to_vec(),
+            });
+        }
+    }
+    Ok(out)
+}
+
 /// Returns `Err(BroadcastError)` if broadcasting is impossible.
 pub fn broadcast_strides(
     src_shape:   &[usize],

--- a/crates/mohu-buffer/tests/allclose_broadcast.rs
+++ b/crates/mohu-buffer/tests/allclose_broadcast.rs
@@ -1,0 +1,22 @@
+use mohu_buffer::Buffer;
+
+#[test]
+fn allclose_broadcasts_scalar() {
+    let a = Buffer::from_slice::<f64>(&[5.0, 5.0]).unwrap();
+    let b = Buffer::from_slice::<f64>(&[5.0]).unwrap();
+    assert!(a.allclose(&b, 0.0, 0.0).unwrap());
+}
+
+#[test]
+fn allclose_same_shape_still_works() {
+    let a = Buffer::from_slice::<f64>(&[1.0, 2.0]).unwrap();
+    let b = Buffer::from_slice::<f64>(&[1.0, 2.0]).unwrap();
+    assert!(a.allclose(&b, 0.0, 0.0).unwrap());
+}
+
+#[test]
+fn allclose_incompatible_shapes_returns_broadcast_error() {
+    let a = Buffer::from_slice::<f64>(&[1.0, 2.0]).unwrap();
+    let b = Buffer::from_slice::<f64>(&[1.0, 2.0, 3.0]).unwrap();
+    assert!(a.allclose(&b, 0.0, 0.0).is_err());
+}


### PR DESCRIPTION
Adds broadcast_shapes helper and broadcasts both operands before comparing (NumPy-compatible). Closes #22