### PR TITLE
Performance: tril and triu use serial element-by-element pointer writes

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -1101,19 +1101,20 @@ impl Buffer {
         let out = self.to_contiguous()?;
         let (rows, cols) = (out.shape()[0], out.shape()[1]);
         let itemsize = out.dtype().itemsize();
-        let zero_bytes = vec![0u8; itemsize];
-        let ptr = unsafe { out.as_mut_ptr() };
-        for r in 0..rows {
-            for c in 0..cols {
-                // zero element if c > r + k
-                if c as i64 > r as i64 + k {
-                    let off = out.layout.byte_offset(&[r, c])?;
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(zero_bytes.as_ptr(), ptr.add(off), itemsize);
-                    }
+        let base = unsafe { out.as_mut_ptr() } as usize;
+        let layout = out.layout.clone();
+        use rayon::prelude::*;
+        (0..rows).into_par_iter().for_each(|r| {
+            let start_col = (r as i64 + k + 1).max(0) as usize;
+            if start_col < cols {
+                let off = layout.byte_offset(&[r, start_col]).expect("valid tril index");
+                let nbytes = (cols - start_col) * itemsize;
+                // SAFETY: each row zeros a disjoint contiguous span in the unique `out` buffer.
+                unsafe {
+                    std::ptr::write_bytes((base + off) as *mut u8, 0, nbytes);
                 }
             }
-        }
+        });
         Ok(out)
     }
 
@@ -1127,18 +1128,20 @@ impl Buffer {
         let out = self.to_contiguous()?;
         let (rows, cols) = (out.shape()[0], out.shape()[1]);
         let itemsize = out.dtype().itemsize();
-        let zero_bytes = vec![0u8; itemsize];
-        let ptr = unsafe { out.as_mut_ptr() };
-        for r in 0..rows {
-            for c in 0..cols {
-                if (c as i64) < (r as i64 + k) {
-                    let off = out.layout.byte_offset(&[r, c])?;
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(zero_bytes.as_ptr(), ptr.add(off), itemsize);
-                    }
+        let base = unsafe { out.as_mut_ptr() } as usize;
+        let layout = out.layout.clone();
+        use rayon::prelude::*;
+        (0..rows).into_par_iter().for_each(|r| {
+            let end_col = (r as i64 + k).max(0).min(cols as i64) as usize;
+            if end_col > 0 {
+                let off = layout.byte_offset(&[r, 0]).expect("valid triu index");
+                let nbytes = end_col * itemsize;
+                // SAFETY: each row zeros a disjoint prefix span in the unique `out` buffer.
+                unsafe {
+                    std::ptr::write_bytes((base + off) as *mut u8, 0, nbytes);
                 }
             }
-        }
+        });
         Ok(out)
     }
 

--- a/crates/mohu-buffer/tests/tril_triu.rs
+++ b/crates/mohu-buffer/tests/tril_triu.rs
@@ -1,0 +1,38 @@
+use mohu_buffer::Buffer;
+use mohu_dtype::DType;
+
+#[test]
+fn tril_zeros_above_diagonal() {
+    let buf = Buffer::from_slice::<f64>(&[1.0, 2.0, 3.0, 4.0])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let lower = buf.tril(0).unwrap();
+    assert_eq!(lower.get::<f64>(&[0, 0]).unwrap(), 1.0);
+    assert_eq!(lower.get::<f64>(&[0, 1]).unwrap(), 0.0);
+    assert_eq!(lower.get::<f64>(&[1, 0]).unwrap(), 3.0);
+    assert_eq!(lower.get::<f64>(&[1, 1]).unwrap(), 4.0);
+}
+
+#[test]
+fn triu_zeros_below_diagonal() {
+    let buf = Buffer::from_slice::<f64>(&[1.0, 2.0, 3.0, 4.0])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let upper = buf.triu(0).unwrap();
+    assert_eq!(upper.get::<f64>(&[0, 0]).unwrap(), 1.0);
+    assert_eq!(upper.get::<f64>(&[0, 1]).unwrap(), 2.0);
+    assert_eq!(upper.get::<f64>(&[1, 0]).unwrap(), 0.0);
+    assert_eq!(upper.get::<f64>(&[1, 1]).unwrap(), 4.0);
+}
+
+#[test]
+fn tril_i32_preserves_dtype() {
+    let buf = Buffer::from_slice::<i32>(&[1, 2, 3, 4])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let lower = buf.tril(0).unwrap();
+    assert_eq!(lower.dtype(), DType::I32);
+}


### PR DESCRIPTION
Zeros above/below the diagonal with Rayon row parallelism and write_bytes on contiguous spans. Closes #24