### PR TITLE
ci: point cargo-deny-action at workspace deny.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: Cargo.toml
+          config: deny.toml


### PR DESCRIPTION
## Summary

Configures `EmbarkStudios/cargo-deny-action@v2` with `manifest-path` and `config` so CI always uses the workspace `deny.toml`.

Closes #28