### PR TITLE
chore: align MSRV to 1.85 across toolchain, CI, and metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,30 @@ jobs:
       - name: Run Python tests
         run: pytest python/tests/ -v
 
+  msrv:
+    name: Rust — MSRV (1.85)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.85
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --workspace
+
+      - name: Test
+        run: cargo test --workspace
+
   deny:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: Cargo.toml
+          config: deny.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ resolver = "2"
 [workspace.package]
 version      = "0.1.0"
 edition      = "2024"
+rust-version = "1.85"
 license      = "MIT"
 authors      = ["mohu contributors"]
 repository   = "https://github.com/mohu-org/mohu"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mohu
 
+[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue?logo=rust)](https://github.com/mohu-org/mohu/blob/main/rust-toolchain.toml)
+
 Rust-powered arrays for Python. Fast, parallel, and built for the future.
 
 mohu is an early-stage NumPy replacement with its core written in Rust. The goal is simple — take everything Python's scientific stack does and do it without the bottlenecks that have been accepted for decades.

--- a/crates/mohu-array/Cargo.toml
+++ b/crates/mohu-array/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-array"
 description = "NdArray<T> — the core N-dimensional array type composing dtype, buffer, shape, and slice info"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-buffer/Cargo.toml
+++ b/crates/mohu-buffer/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-buffer"
 description = "Raw buffer allocation, memory layout, and stride arithmetic for mohu arrays"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-core/Cargo.toml
+++ b/crates/mohu-core/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-core"
 description = "Re-export facade — depends on mohu-dtype, mohu-buffer, and mohu-array for convenience"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-dtype/Cargo.toml
+++ b/crates/mohu-dtype/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-dtype"
 description = "DType enum, scalar type traits, and type promotion rules for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-error/Cargo.toml
+++ b/crates/mohu-error/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-error"
 description = "Shared error types for mohu — zero-dependency foundation used by every crate"
 version.workspace    = true
 edition.workspace    = true
+rust-version.workspace = true
 license.workspace    = true
 authors.workspace    = true
 repository.workspace = true

--- a/crates/mohu-fft/Cargo.toml
+++ b/crates/mohu-fft/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-fft"
 description = "FFT, IFFT, RFFT, and 2-D transforms for mohu arrays"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-index/Cargo.toml
+++ b/crates/mohu-index/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-index"
 description = "Advanced indexing for mohu: fancy, boolean mask, take/put, slice objects"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-io/Cargo.toml
+++ b/crates/mohu-io/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-io"
 description = "Array serialization and I/O: .npy/.npz, CSV, Apache Arrow IPC, and memory-mapped files"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-masked/Cargo.toml
+++ b/crates/mohu-masked/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-masked"
 description = "Masked arrays — null / invalid value propagation for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-ops/Cargo.toml
+++ b/crates/mohu-ops/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-ops"
 description = "Element-wise arithmetic, comparison, logical, and broadcasting operations for mohu arrays"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-random/Cargo.toml
+++ b/crates/mohu-random/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-random"
 description = "PRNG engines and statistical distributions for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-simd/Cargo.toml
+++ b/crates/mohu-simd/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-simd"
 description = "AVX2 / AVX-512 / NEON SIMD kernel primitives for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-sparse/Cargo.toml
+++ b/crates/mohu-sparse/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-sparse"
 description = "COO / CSR / CSC sparse matrix formats and operations for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-special/Cargo.toml
+++ b/crates/mohu-special/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-special"
 description = "Special mathematical functions for mohu: erf, gamma, beta, Bessel, …"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-stats/Cargo.toml
+++ b/crates/mohu-stats/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-stats"
 description = "Statistical functions: descriptive stats, distributions, random sampling, and hypothesis testing"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-testing/Cargo.toml
+++ b/crates/mohu-testing/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-testing"
 description = "Test utilities, fixtures, and property-test helpers for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-ufunc/Cargo.toml
+++ b/crates/mohu-ufunc/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-ufunc"
 description = "Universal-function protocol for mohu: broadcast, reduce, accumulate, outer"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "stable"
+channel    = "1.85"
 components = ["rustfmt", "clippy", "rust-src"]
 targets    = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
## Summary

- `rust-toolchain.toml` pins channel `1.85` (matches `clippy.toml` / `scripts/check-msrv.sh`)
- `[workspace.package] rust-version = "1.85"` with inheritance in all workspace crates
- MSRV badge in `README.md`
- New `msrv` CI job on `dtolnay/rust-toolchain@1.85.0`

Closes #30