### PR TITLE
docs: add NumPy API coverage tracker (coverage.toml)

### DIFF
--- a/docs/numpy-migration/api-mapping.md
+++ b/docs/numpy-migration/api-mapping.md
@@ -1,0 +1,38 @@
+# NumPy API mapping
+
+This page is generated from the machine-readable tracker at [`numpy-api-coverage.toml`](../../numpy-api-coverage.toml) in the repository root.
+
+## Coverage summary
+
+Run the helper script to print implemented vs total entries:
+
+```bash
+./scripts/numpy-coverage-summary.sh
+```
+
+## Status legend
+
+| Status | Meaning |
+|--------|---------|
+| `implemented` | mohu provides an equivalent with matching intent |
+| `partial` | Subset of NumPy behaviour or missing edge cases |
+| `missing` | Not yet implemented |
+
+## Tracked APIs (sample)
+
+| NumPy | mohu | Status | Crate |
+|-------|------|--------|-------|
+| `np.zeros` | `Buffer::zeros` | implemented | mohu-buffer |
+| `np.ones` | `Buffer::ones` | implemented | mohu-buffer |
+| `np.arange` | `Buffer::arange` | implemented | mohu-buffer |
+| `np.reshape` | `Buffer::reshape` | implemented | mohu-buffer |
+| `np.sum` | `Buffer::sum_all_f64` / `sum_axis` | partial | mohu-buffer |
+| `np.matmul` | — | missing | mohu-ops |
+| `np.fft.fft` | — | missing | mohu-fft |
+
+See the TOML file for the full list. Add a new `[[api]]` block when landing NumPy-compatible surface area.
+
+## Future work
+
+- Re-run NumPy's test suite with `import mohu as np` (pytest plugin)
+- Publish compatibility percentage as a CI badge

--- a/numpy-api-coverage.toml
+++ b/numpy-api-coverage.toml
@@ -1,0 +1,199 @@
+# NumPy API coverage tracker for mohu (see issue #33).
+# Status: implemented | partial | missing
+# Update this file when adding NumPy-compatible APIs.
+
+[meta]
+schema  = 1
+updated = "2026-05-17"
+
+# ── Array creation ─────────────────────────────────────────────────────────────
+
+[[api]]
+numpy  = "np.zeros"
+mohu   = "mohu_buffer::Buffer::zeros"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.ones"
+mohu   = "mohu_buffer::Buffer::ones"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.full"
+mohu   = "mohu_buffer::Buffer::full"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.array"
+mohu   = "mohu_buffer::Buffer::from_slice"
+status = "partial"
+notes  = "1-D contiguous only; no nested sequences yet"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.arange"
+mohu   = "mohu_buffer::Buffer::arange"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.linspace"
+mohu   = "mohu_buffer::Buffer::linspace"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.eye"
+mohu   = "mohu_buffer::Buffer::eye"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.diag"
+mohu   = "mohu_buffer::Buffer::diag"
+status = "implemented"
+crate  = "mohu-buffer"
+
+# ── Shape & layout ─────────────────────────────────────────────────────────────
+
+[[api]]
+numpy  = "np.reshape"
+mohu   = "mohu_buffer::Buffer::reshape"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.transpose"
+mohu   = "mohu_buffer::Buffer::transpose"
+status = "partial"
+notes  = "2-D swap only; use permute for general axes"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.transpose (axes)"
+mohu   = "mohu_buffer::Buffer::permute"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.expand_dims"
+mohu   = "mohu_buffer::Buffer::expand_dims"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.squeeze"
+mohu   = "mohu_buffer::Buffer::squeeze"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.broadcast_to"
+mohu   = "mohu_buffer::Buffer::broadcast_to"
+status = "implemented"
+crate  = "mohu-buffer"
+
+# ── Indexing & manipulation ────────────────────────────────────────────────────
+
+[[api]]
+numpy  = "ndarray.__getitem__ (slice)"
+mohu   = "mohu_buffer::Buffer::slice_axis"
+status = "partial"
+notes  = "Per-axis SliceArg; not full tuple slicing yet"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.flip"
+mohu   = "mohu_buffer::Buffer::flip"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.tril"
+mohu   = "mohu_buffer::Buffer::tril"
+status = "implemented"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.triu"
+mohu   = "mohu_buffer::Buffer::triu"
+status = "implemented"
+crate  = "mohu-buffer"
+
+# ── Type system ────────────────────────────────────────────────────────────────
+
+[[api]]
+numpy  = "np.dtype"
+mohu   = "mohu_dtype::DType"
+status = "implemented"
+crate  = "mohu-dtype"
+
+[[api]]
+numpy  = "np.result_type"
+mohu   = "mohu_dtype::promote::result_type"
+status = "implemented"
+crate  = "mohu-dtype"
+
+[[api]]
+numpy  = "np.can_cast"
+mohu   = "mohu_dtype::promote::can_cast"
+status = "implemented"
+crate  = "mohu-dtype"
+
+[[api]]
+numpy  = "astype"
+mohu   = "mohu_buffer::Buffer::cast"
+status = "implemented"
+crate  = "mohu-buffer"
+
+# ── Reductions ─────────────────────────────────────────────────────────────────
+
+[[api]]
+numpy  = "np.sum"
+mohu   = "mohu_buffer::Buffer::sum_all_f64 / sum_axis"
+status = "partial"
+notes  = "sum_axis dtype promotion in progress; no full ufunc yet"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.mean"
+mohu   = "mohu_buffer::Buffer::mean_all_f64"
+status = "partial"
+notes  = "Global mean only"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.allclose"
+mohu   = "mohu_buffer::Buffer::allclose"
+status = "implemented"
+crate  = "mohu-buffer"
+
+# ── Planned / missing (representative) ─────────────────────────────────────────
+
+[[api]]
+numpy  = "np.matmul"
+mohu   = ""
+status = "missing"
+crate  = "mohu-ops"
+
+[[api]]
+numpy  = "np.where"
+mohu   = "mohu_buffer::ops::where_select"
+status = "partial"
+notes  = "Buffer-level select; not full np.where broadcasting"
+crate  = "mohu-buffer"
+
+[[api]]
+numpy  = "np.fft.fft"
+mohu   = "mohu_fft::fft"
+status = "missing"
+crate  = "mohu-fft"
+
+[[api]]
+numpy  = "np.save / np.load"
+mohu   = "mohu_io"
+status = "missing"
+crate  = "mohu-io"

--- a/scripts/numpy-coverage-summary.sh
+++ b/scripts/numpy-coverage-summary.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Print NumPy API coverage stats from numpy-api-coverage.toml.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FILE="$ROOT/numpy-api-coverage.toml"
+
+if [[ ! -f "$FILE" ]]; then
+  echo "missing $FILE" >&2
+  exit 1
+fi
+
+total=$(grep -c '^status = ' "$FILE" || true)
+implemented=$(grep -c '^status = "implemented"' "$FILE" || true)
+partial=$(grep -c '^status = "partial"' "$FILE" || true)
+missing=$(grep -c '^status = "missing"' "$FILE" || true)
+
+pct=0
+if [[ "$total" -gt 0 ]]; then
+  pct=$(( (implemented * 100) / total ))
+fi
+
+echo "NumPy API coverage (tracked entries)"
+echo "  total:       $total"
+echo "  implemented: $implemented"
+echo "  partial:     $partial"
+echo "  missing:     $missing"
+echo "  implemented%: ${pct}% (of tracked entries only)"


### PR DESCRIPTION
## Summary

- Adds `numpy-api-coverage.toml` mapping `np.*` entries to mohu equivalents with `implemented` / `partial` / `missing` status
- Fills in `docs/numpy-migration/api-mapping.md` (referenced by mdBook SUMMARY but previously missing)
- Adds `scripts/numpy-coverage-summary.sh` to print coverage counts (currently 20/29 implemented in the tracker)

Future work (pytest re-run, CI badge) is documented in the mapping page.

Closes #33