### PR TITLE
perf(buffer): eliminate per-element Vec alloc in sum_axis

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -1291,40 +1291,90 @@ impl Buffer {
                 "sum_axis: axis {axis} out of bounds for ndim {}", self.ndim()
             )));
         }
-        // Build output shape
         let mut out_shape: Vec<usize> = self.shape().to_vec();
         let axis_size = out_shape[axis];
-        if keepdims { out_shape[axis] = 1; } else { out_shape.remove(axis); }
+        if keepdims {
+            out_shape[axis] = 1;
+        } else {
+            out_shape.remove(axis);
+        }
 
         let out = Self::zeros(DType::F64, &out_shape)?;
-        let out_raw = unsafe { out.as_mut_ptr() as *mut f64 };
-        let _ = out.len(); // shape check only; iteration is index-driven
+        let out_len = out.len();
+        if out_len == 0 {
+            return Ok(out);
+        }
 
-        // For each output element, sum the corresponding slice along axis.
-        // Iterate over all positions in the output.
-        use crate::strides::NdIndexIter;
+        let out_base = unsafe { out.as_mut_ptr() as usize };
         let out_shape_full: Vec<usize> = out.shape().to_vec();
-
-        // Build src index from out index by inserting the axis.
+        let ndim = self.ndim();
+        let axis_stride = self.strides()[axis];
         let itemsize = self.dtype.itemsize();
-        let src_raw  = self.as_ptr();
+        let src_base = self.as_ptr() as usize;
+        let dtype = self.dtype;
+        let layout = &self.layout;
 
-        for (out_flat, out_idx) in NdIndexIter::new(&out_shape_full).enumerate() {
-            let mut acc = 0.0f64;
-            for k in 0..axis_size {
-                // Build source index
-                let mut src_idx = out_idx.to_vec();
-                if keepdims {
-                    src_idx[axis] = k;
-                } else {
-                    src_idx.insert(axis, k);
+        let write_src_idx = |src_idx: &mut [usize], out_idx: &[usize]| {
+            if keepdims {
+                src_idx.copy_from_slice(out_idx);
+            } else {
+                let mut j = 0;
+                for i in 0..ndim {
+                    if i == axis {
+                        src_idx[i] = 0;
+                    } else {
+                        src_idx[i] = out_idx[j];
+                        j += 1;
+                    }
                 }
-                let off = self.layout.byte_offset(&src_idx)?;
-                // Read element as f64 via dispatch
-                let val = read_as_f64(unsafe { src_raw.add(off) }, self.dtype, itemsize);
-                acc += val;
             }
-            unsafe { out_raw.add(out_flat).write(acc); }
+        };
+
+        if out_len >= 512 {
+            use rayon::prelude::*;
+            (0..out_len).into_par_iter().for_each(|out_flat| {
+                let mut out_idx = vec![0usize; out_shape_full.len()];
+                let mut rest = out_flat;
+                for i in (0..out_shape_full.len()).rev() {
+                    let dim = out_shape_full[i];
+                    out_idx[i] = rest % dim;
+                    rest /= dim;
+                }
+                let mut src_idx = vec![0usize; ndim];
+                write_src_idx(&mut src_idx, &out_idx);
+                let base = layout.byte_offset_unchecked(&src_idx) as isize;
+                let mut acc = 0.0f64;
+                for k in 0..axis_size {
+                    let off = (base + k as isize * axis_stride) as usize;
+                    acc += read_as_f64(
+                        unsafe { (src_base + off) as *const u8 },
+                        dtype,
+                        itemsize,
+                    );
+                }
+                unsafe {
+                    (out_base as *mut f64).add(out_flat).write(acc);
+                }
+            });
+        } else {
+            use crate::strides::NdIndexIter;
+            let mut src_idx = vec![0usize; ndim];
+            for (out_flat, out_idx) in NdIndexIter::new(&out_shape_full).enumerate() {
+                write_src_idx(&mut src_idx, out_idx.as_slice());
+                let base = layout.byte_offset_unchecked(&src_idx) as isize;
+                let mut acc = 0.0f64;
+                for k in 0..axis_size {
+                    let off = (base + k as isize * axis_stride) as usize;
+                    acc += read_as_f64(
+                        unsafe { (src_base + off) as *const u8 },
+                        dtype,
+                        itemsize,
+                    );
+                }
+                unsafe {
+                    (out_base as *mut f64).add(out_flat).write(acc);
+                }
+            }
         }
 
         Ok(out)

--- a/crates/mohu-buffer/tests/sum_axis.rs
+++ b/crates/mohu-buffer/tests/sum_axis.rs
@@ -1,0 +1,37 @@
+use mohu_buffer::Buffer;
+use mohu_dtype::DType;
+
+#[test]
+fn sum_axis_matches_manual_2d() {
+    let data: Vec<i32> = vec![1, 2, 3, 4, 5, 6];
+    let buf = Buffer::from_slice(&data).unwrap().reshape(&[2, 3]).unwrap();
+
+    let axis0 = buf.sum_axis(0, false).unwrap();
+    assert_eq!(axis0.shape(), &[3]);
+    assert_eq!(axis0.to_vec::<f64>().unwrap(), vec![5.0, 7.0, 9.0]);
+
+    let axis1 = buf.sum_axis(1, false).unwrap();
+    assert_eq!(axis1.shape(), &[2]);
+    assert_eq!(axis1.to_vec::<f64>().unwrap(), vec![6.0, 15.0]);
+}
+
+#[test]
+fn sum_axis_keepdims_preserves_axis() {
+    let buf = Buffer::from_slice(&[1.0_f64, 2.0, 3.0, 4.0])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let summed = buf.sum_axis(0, true).unwrap();
+    assert_eq!(summed.shape(), &[1, 2]);
+    assert_eq!(summed.to_vec::<f64>().unwrap(), vec![4.0, 6.0]);
+}
+
+#[test]
+fn sum_axis_partial_sums_equal_total() {
+    let buf = Buffer::arange(0.0, 12.0, 1.0, DType::F64).unwrap().reshape(&[3, 4]).unwrap();
+    let total = buf.sum_all_f64().unwrap();
+    for axis in 0..buf.ndim() {
+        let partial = buf.sum_axis(axis, false).unwrap().sum_all_f64().unwrap();
+        assert!((partial - total).abs() < 1e-9);
+    }
+}


### PR DESCRIPTION
## Summary

- Reuses a single source index buffer instead of `out_idx.to_vec()` + `insert` per inner iteration
- Sums along the reduction axis via byte stride walking (`base + k * axis_stride`)
- Parallelizes over output elements with Rayon when `out_len >= 512`

## Tests

- `sum_axis_matches_manual_2d` — 2×3 integer matrix, both axes
- `sum_axis_keepdims_preserves_axis`
- `sum_axis_partial_sums_equal_total` — partial sums match `sum_all_f64`

Closes #13