### PR TITLE
ci: run Rust build and test on Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@ env:
 
 jobs:
   rust-build:
-    name: Rust — Build & Test
-    runs-on: ubuntu-latest
+    name: Rust — Build & Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Adds a `strategy.matrix.os` to `rust-build` covering `ubuntu-latest`, `macos-latest`, and `windows-latest` with `fail-fast: false`.

Closes #16