### PR TITLE
feat(error): add MohuError is_oom, is_io, and is_dlpack predicates

### DIFF
--- a/crates/mohu-error/src/error.rs
+++ b/crates/mohu-error/src/error.rs
@@ -647,6 +647,28 @@ impl MohuError {
         )
     }
 
+    /// Returns `true` if this is an out-of-memory allocation failure.
+    pub fn is_oom(&self) -> bool {
+        matches!(self, Self::AllocationFailed { .. })
+    }
+
+    /// Returns `true` if this is a system I/O error.
+    pub fn is_io(&self) -> bool {
+        matches!(self, Self::Io(_))
+    }
+
+    /// Returns `true` if this is a DLPack interop error.
+    pub fn is_dlpack(&self) -> bool {
+        matches!(
+            self,
+            Self::DLPackUnsupportedDevice { .. }
+                | Self::DLPackVersionMismatch { .. }
+                | Self::DLPackNullPointer
+                | Self::DLPackUnsupportedDType { .. }
+                | Self::DLPackInvalid(_)
+        )
+    }
+
     // -------------------------------------------------------------------------
     // Convenience constructors
     // -------------------------------------------------------------------------

--- a/crates/mohu-error/tests/error_tests.rs
+++ b/crates/mohu-error/tests/error_tests.rs
@@ -1,0 +1,39 @@
+use mohu_error::MohuError;
+
+#[test]
+fn is_oom_only_for_allocation_failed() {
+    assert!(MohuError::alloc(1024).is_oom());
+    assert!(!MohuError::bug("x").is_oom());
+    assert!(!MohuError::Io(std::io::Error::other("disk")).is_oom());
+}
+
+#[test]
+fn is_io_only_for_io_variant() {
+    assert!(MohuError::Io(std::io::Error::other("read")).is_io());
+    assert!(!MohuError::alloc(1).is_io());
+    assert!(!MohuError::ShapeMismatch {
+        expected: vec![2],
+        got: vec![3],
+    }
+    .is_io());
+}
+
+#[test]
+fn is_dlpack_covers_all_dlpack_variants() {
+    assert!(MohuError::DLPackNullPointer.is_dlpack());
+    assert!(MohuError::DLPackUnsupportedDevice { device_type: 1 }.is_dlpack());
+    assert!(MohuError::DLPackVersionMismatch {
+        supported_major: 1,
+        got_major: 2,
+        got_minor: 0,
+    }
+    .is_dlpack());
+    assert!(MohuError::DLPackUnsupportedDType {
+        code: 1,
+        bits: 32,
+        lanes: 1,
+    }
+    .is_dlpack());
+    assert!(MohuError::DLPackInvalid("bad".into()).is_dlpack());
+    assert!(!MohuError::bug("x").is_dlpack());
+}


### PR DESCRIPTION
## Summary

- `MohuError::is_oom()` — `AllocationFailed` only
- `MohuError::is_io()` — `Io(_)` only
- `MohuError::is_dlpack()` — all five DLPack variants

## Tests

`crates/mohu-error/tests/error_tests.rs` (3 cases)

Closes #59