### PR TITLE
feat(dtype): add category iterators for floats, integers, complex

### DIFF
--- a/crates/mohu-dtype/src/dtype.rs
+++ b/crates/mohu-dtype/src/dtype.rs
@@ -509,6 +509,31 @@ impl DType {
         }
     }
 
+    /// Returns an iterator over all floating-point (non-complex) dtypes.
+    pub fn iter_floats() -> impl Iterator<Item = DType> {
+        Self::all().filter(|d| d.is_float())
+    }
+
+    /// Returns an iterator over all integer dtypes (signed and unsigned).
+    pub fn iter_integers() -> impl Iterator<Item = DType> {
+        Self::all().filter(|d| d.is_integer())
+    }
+
+    /// Returns an iterator over complex dtypes (`C64`, `C128`).
+    pub fn iter_complex() -> impl Iterator<Item = DType> {
+        Self::all().filter(|d| d.is_complex())
+    }
+
+    /// Returns an iterator over signed integer dtypes.
+    pub fn iter_signed() -> impl Iterator<Item = DType> {
+        Self::all().filter(|d| d.is_signed_integer())
+    }
+
+    /// Returns an iterator over unsigned integer dtypes.
+    pub fn iter_unsigned() -> impl Iterator<Item = DType> {
+        Self::all().filter(|d| d.is_unsigned_integer())
+    }
+
     /// Returns an iterator over all variants in definition order.
     pub fn all() -> impl Iterator<Item = DType> {
         ALL_DTYPES.iter().copied()

--- a/crates/mohu-dtype/tests/dtype_iterators.rs
+++ b/crates/mohu-dtype/tests/dtype_iterators.rs
@@ -1,0 +1,33 @@
+use mohu_dtype::DType;
+
+#[test]
+fn iter_floats_count_and_predicate() {
+    let floats: Vec<_> = DType::iter_floats().collect();
+    assert_eq!(floats.len(), 4);
+    assert!(floats.iter().all(|d| d.is_float()));
+}
+
+#[test]
+fn iter_integers_count_and_predicate() {
+    let ints: Vec<_> = DType::iter_integers().collect();
+    assert_eq!(ints.len(), 8);
+    assert!(ints.iter().all(|d| d.is_integer()));
+}
+
+#[test]
+fn iter_complex_count_and_predicate() {
+    let cx: Vec<_> = DType::iter_complex().collect();
+    assert_eq!(cx.len(), 2);
+    assert!(cx.iter().all(|d| d.is_complex()));
+}
+
+#[test]
+fn iter_signed_and_unsigned_partition_integers() {
+    let signed: Vec<_> = DType::iter_signed().collect();
+    let unsigned: Vec<_> = DType::iter_unsigned().collect();
+    assert_eq!(signed.len(), 4);
+    assert_eq!(unsigned.len(), 4);
+    assert!(signed.iter().all(|d| d.is_signed_integer()));
+    assert!(unsigned.iter().all(|d| d.is_unsigned_integer()));
+    assert_eq!(signed.len() + unsigned.len(), DType::iter_integers().count());
+}


### PR DESCRIPTION
## Summary

- `DType::iter_floats()` — F16, BF16, F32, F64
- `DType::iter_integers()` — all 8 integer types
- `DType::iter_complex()` — C64, C128
- `DType::iter_signed()` / `iter_unsigned()` — partition integers

## Tests

`crates/mohu-dtype/tests/dtype_iterators.rs` verifies counts and predicate consistency.

Closes #57