### PR TITLE
fix(ci): skip python-test until mohu-py exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         run: cargo fmt --all -- --check
 
   python-test:
+    # Skip until crates/mohu-py is bootstrapped (see issue #7).
+    if: ${{ hashFiles('crates/mohu-py/Cargo.toml') != '' }}
     name: Python — ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     needs: rust-build


### PR DESCRIPTION
## Summary
Gates the `python-test` CI job on `crates/mohu-py/Cargo.toml` so the workflow does not fail while the Python bindings crate is not yet present.

Closes #7