### PR TITLE
ci: add Python 3.14-dev to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,15 @@ jobs:
         run: cargo fmt --all -- --check
 
   python-test:
+    # Skip until crates/mohu-py is bootstrapped (see issue #7).
+    if: ${{ hashFiles('crates/mohu-py/Cargo.toml') != '' }}
     name: Python — ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     needs: rust-build
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14-dev"]
     steps:
       - uses: actions/checkout@v4
 
@@ -69,6 +71,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ startsWith(matrix.python-version, '3.14') }}
 
       - name: Install maturin
         run: pip install maturin


### PR DESCRIPTION
## Summary
- Skips `python-test` until `crates/mohu-py/Cargo.toml` exists (closes #7).
- Adds `3.14-dev` to the Python matrix with `allow-prereleases` (closes #17).

## Test plan
- [x] Workflow YAML validates (matrix + `if` + expression syntax)