### PR TITLE
docs: rewrite CONTRIBUTING.md with full workflow and crate map

### DIFF
--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -1,14 +1,18 @@
 name: PR Bot
 
+# pull_request_target runs with base-repo token (write access),
+# even for fork PRs. We never checkout untrusted fork code here.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
+  # ── Auto Label ──────────────────────────────────────────────────────────────
   label:
     name: Auto Label
     runs-on: ubuntu-latest
@@ -19,30 +23,34 @@ jobs:
           configuration-path: .github/labeler.yml
           sync-labels: true
 
+  # ── Auto Assign Reviewer ────────────────────────────────────────────────────
   assign-reviewer:
     name: Auto Assign Reviewer
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - name: Assign reviewer from CODEOWNERS
-        uses: kentaro-m/auto-assign-action@v2.0.0
+      - uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           configuration-path: .github/auto_assign.yml
 
+  # ── PR Summary Comment ──────────────────────────────────────────────────────
   comment:
     name: PR Summary Comment
     runs-on: ubuntu-latest
     if: github.event.action == 'opened'
     steps:
+      # Safe: fetch-depth 0 on base ref only — no fork code executed
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
 
-      - name: Get changed files
+      - name: Get changed files via API
         id: changed
         uses: tj-actions/changed-files@v46
         with:
-          separator: "\n"
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Count changed crates
         id: crates
@@ -61,9 +69,9 @@ jobs:
 
             | Item | Value |
             |------|-------|
-            | Branch | `${{ github.head_ref }}` |
+            | Branch | `${{ github.event.pull_request.head.ref }}` |
             | Changed crates | `${{ steps.crates.outputs.list }}` |
             | Files changed | ${{ steps.changed.outputs.all_changed_files_count }} |
 
-            CI will run: **build**, **test**, **clippy**, **fmt**, **cargo-deny**.
-            Reviewer assigned from CODEOWNERS (`@mohu-org/core`).
+            CI will run: **build**, **test**, **clippy**, **fmt**, **cargo-deny**, **DCO**, **semver**.
+            Reviewer assigned from CODEOWNERS.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,169 @@
+# AGENTS.md — mohu
+
+Guidance for AI coding agents (Codex, Claude, Copilot Workspace, etc.) working in this repository. Supplements `CLAUDE.md` with agent-specific behavior rules.
+
+---
+
+## Read first
+
+Before writing any code, read:
+
+1. `CLAUDE.md` — build commands, architecture, error handling, clippy rules, commit rules
+2. `CRATE_MAP.md` — exact public API surface per crate
+3. `CONTRIBUTING.md` — PR workflow, DCO, branch naming
+
+---
+
+## Repository orientation
+
+```
+mohu/
+├── Cargo.toml          # workspace root — all dep versions here
+├── crates/             # 17 workspace crates
+│   ├── mohu-error/     # zero-dep error foundation
+│   ├── mohu-dtype/     # scalar types and type promotion
+│   ├── mohu-buffer/    # raw allocation, layout, strides (unsafe allowed here)
+│   ├── mohu-array/     # NdArray<T> type
+│   ├── mohu-core/      # re-export facade only
+│   ├── mohu-simd/      # SIMD intrinsics (unsafe allowed here)
+│   ├── mohu-ufunc/     # universal-function protocol
+│   ├── mohu-index/     # advanced indexing
+│   ├── mohu-ops/       # element-wise ops and broadcasting
+│   ├── mohu-fft/       # FFT transforms
+│   ├── mohu-random/    # PRNG and distributions
+│   ├── mohu-special/   # special math functions
+│   ├── mohu-stats/     # descriptive stats and hypothesis tests
+│   ├── mohu-sparse/    # COO/CSR/CSC formats
+│   ├── mohu-masked/    # masked arrays
+│   ├── mohu-io/        # file I/O
+│   └── mohu-testing/   # test utilities (never a non-test dep)
+├── benches/            # workspace-level benchmarks
+├── docs/               # mdBook source and RFCs
+└── .github/
+    ├── workflows/
+    │   ├── ci.yml      # 13-job CI pipeline
+    │   └── release.yml # tag-triggered cross-compilation + release
+    ├── labeler.yml     # PR auto-labeling rules
+    └── auto_assign.yml # PR auto-reviewer config
+```
+
+---
+
+## Before writing code
+
+1. **Read every file you will modify** — do not edit blind.
+2. **Check the layer** — identify which crate owns the concept. Never add logic to the wrong layer.
+3. **Check `CRATE_MAP.md`** — confirm the public items you need already exist before reimplementing them.
+4. **Run `cargo check -p <crate>`** — verify the workspace builds before making changes.
+
+---
+
+## Crate layer rules (hard constraints)
+
+| Layer | Crates | May depend on |
+|-------|--------|---------------|
+| Foundation | error, dtype, buffer, array, core | Only lower foundation crates |
+| Dispatch | simd, ufunc, index | Foundation only |
+| Compute | ops, fft, random, special, stats | Foundation + Dispatch |
+| Extensions | sparse, masked | Foundation + Dispatch + Compute |
+| IO/Tooling | io, testing | Foundation + Compute |
+
+Violating layer order = immediate CI failure. Check before adding any `[dependencies]` entry.
+
+---
+
+## Code style rules
+
+- No `unwrap()` or `expect()` in library code. Use `?` and `MohuError`.
+- No `println!`/`eprintln!` in library code. Use `tracing::debug!` / `tracing::warn!`.
+- No `todo!()` or `unimplemented!()` in non-test code. Implement it or do not add it.
+- Every `unsafe` block needs a `// SAFETY:` comment. Unsafe is only permitted in `mohu-buffer` and `mohu-simd`.
+- Float comparisons in tests must use `mohu_testing::approx::assert_allclose` — never `assert_eq!` on `f32`/`f64`.
+- Public API items need doc comments with at least one `# Example` block.
+
+---
+
+## What to verify after every change
+
+```sh
+cargo check --workspace --all-features          # fast type check
+cargo clippy -p <changed-crate> --all-targets -- -D warnings
+cargo test -p <changed-crate> --all-features
+cargo fmt --all -- --check
+```
+
+Run the full suite (`cargo test --workspace`) before opening a PR.
+
+---
+
+## Commit format (mandatory)
+
+```
+<type>(<scope>): <subject>
+```
+
+- `type`: feat / fix / perf / refactor / doc / test / chore / ci
+- `scope`: crate name without `mohu-` prefix, e.g. `buffer`, `ops`, `error`
+- `subject`: imperative, under 72 chars, no trailing period
+- Must include `Signed-off-by` line — use `git commit -s`
+- No mention of AI tools, Claude, Codex, or Copilot anywhere in the message
+
+Examples:
+```
+feat(array): add strided window iterator
+fix(buffer): align allocation to SIMD_ALIGN on aarch64
+perf(ops): use AVX2 path for f32 horizontal sum
+test(error): add proptest for MultiError extend_from
+ci: add musl cross-compile target
+```
+
+---
+
+## PR rules
+
+- One logical change per PR. Do not bundle unrelated fixes.
+- Title = commit subject format above.
+- Target `mohu-org/mohu:main`.
+- All commits must be signed (`Signed-off-by`). DCO check blocks merge.
+- Required status: `CI Pass` (the `ci-pass` job aggregates all 13 checks).
+- Do not force-push after review — amend is allowed only before first review comment.
+
+---
+
+## Things agents commonly get wrong in this repo
+
+| Mistake | Correct approach |
+|---------|-----------------|
+| Adding `anyhow` or `Box<dyn Error>` | Use `MohuError` and `MohuResult<T>` |
+| Using `unwrap()` in library code | Propagate with `?` and add context |
+| Adding a dependency to the wrong layer | Check the layer table above first |
+| Comparing floats with `assert_eq!` | Use `assert_allclose` from `mohu-testing` |
+| Adding `println!` for debug output | Use `tracing::debug!` |
+| Writing unsafe without `// SAFETY:` | Always document the invariant |
+| Editing `Cargo.lock` directly | Never — `cargo` manages it |
+| Using `git add .` | Stage files explicitly by name |
+| Forgetting `-s` in commit | `git commit -s` — DCO is required |
+| Adding logic to `mohu-core` | It is a re-export facade — no logic |
+| Pinning versions in crate `Cargo.toml` | Use `{ workspace = true }` |
+
+---
+
+## CI pipeline summary
+
+All 13 jobs must pass (aggregated under `ci-pass`):
+
+| Job | What it checks |
+|-----|---------------|
+| `dco` | Every commit has `Signed-off-by` (PR only) |
+| `fmt` | `rustfmt` — no diff |
+| `clippy` | Zero warnings, `-D warnings` |
+| `deny` | No banned deps, no unlicensed deps, no advisories |
+| `unused-deps` | No unused `[dependencies]` entries |
+| `build` | Workspace builds with all features |
+| `doc` | Docs build with `-D warnings` |
+| `msrv` | Builds on Rust 1.85 |
+| `bench-check` | All benchmarks compile |
+| `semver` | No accidental breaking API changes (PR only) |
+| `cross` | Builds for aarch64-linux, aarch64-darwin, x86_64-musl |
+| `coverage` | Test coverage reported to Codecov |
+| `miri` | `mohu-buffer` unsafe code passes Miri strict provenance |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# CLAUDE.md — mohu
+
+AI assistant guide for the mohu workspace. Read this before touching any code.
+
+---
+
+## What this project is
+
+mohu is a NumPy-equivalent scientific computing library written in Rust, with Python bindings via PyO3. It is a Cargo workspace of 17 crates arranged in strict dependency layers.
+
+---
+
+## Build & test commands
+
+```sh
+cargo build --workspace --all-features          # full build
+cargo test --workspace --all-features           # all tests
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all
+cargo doc --workspace --no-deps --all-features
+cargo deny check                                # advisories + licenses + bans
+cargo machete                                   # unused deps
+cargo bench --workspace --no-run --all-features # verify benches compile
+```
+
+MSRV is **1.85** (Rust edition 2024). Never use syntax or APIs above 1.85.
+
+---
+
+## Crate dependency layers
+
+Only depend downward. Never add an upward dependency.
+
+```
+Foundation:   mohu-error → mohu-dtype → mohu-buffer → mohu-array → mohu-core
+Dispatch:     mohu-simd, mohu-ufunc, mohu-index
+Compute:      mohu-ops, mohu-fft, mohu-random, mohu-special, mohu-stats
+Extensions:   mohu-sparse, mohu-masked
+IO/Tooling:   mohu-io, mohu-testing
+```
+
+`mohu-error` has zero internal dependencies. Every other crate may depend on it.
+`mohu-core` is a re-export facade only — no logic lives there.
+
+---
+
+## Workspace Cargo.toml
+
+All external dependency versions live in `[workspace.dependencies]` in the root `Cargo.toml`. Crates reference them as `dep = { workspace = true }`. Never pin a version inside a crate's own `Cargo.toml` unless there is a hard incompatibility.
+
+---
+
+## Error handling rules
+
+- Use `MohuError` from `mohu-error` everywhere — never `anyhow`, never `Box<dyn Error>`.
+- Wrap context with `.context("what was being attempted")` or `.with_context(|| ...)`.
+- Never silently drop errors. Every `?` must propagate or be explicitly handled.
+- Use `MultiError` when a pass must collect all failures before returning.
+- Use `bail!` and `ensure!` macros from `mohu-error` — not manual `return Err(...)`.
+
+---
+
+## Unsafe code rules
+
+- Unsafe is only allowed in `mohu-buffer` (allocation, DLPack FFI) and `mohu-simd` (intrinsics).
+- Every `unsafe` block must have a `// SAFETY:` comment explaining the invariant.
+- All new unsafe in `mohu-buffer` is covered by Miri in CI — keep it that way.
+- Do not introduce unsafe in any other crate without opening an RFC first.
+
+---
+
+## Clippy configuration
+
+`clippy.toml` sets:
+- MSRV: 1.85
+- `cognitive-complexity-threshold`: 30
+- `too-many-arguments-threshold`: 10
+- `type-complexity-threshold`: 400
+
+CI runs `-D warnings` — zero warnings allowed. Fix clippy, do not `#[allow]` unless the lint is genuinely wrong, and document why.
+
+---
+
+## Testing rules
+
+- Unit tests: `#[cfg(test)]` at the bottom of the source file being tested.
+- Integration tests: `crates/<name>/tests/`.
+- Property tests: use `proptest` via `mohu-testing::strategies`.
+- Float comparison: use `mohu-testing::approx::assert_allclose` — never `==` on floats.
+- No `unimplemented!()`, `todo!()`, or `panic!("not yet")` in non-test code.
+- `mohu-testing` must not be a dependency of any non-test crate.
+
+---
+
+## Commit rules
+
+- One-line subject only — no body.
+- Imperative mood: "add", "fix", "update".
+- Under 72 characters.
+- Always sign off: `git commit -s` (DCO). Signed-off-by must appear.
+- Conventional Commits prefix required: `feat`, `fix`, `perf`, `refactor`, `doc`, `test`, `chore`, `ci`.
+- Never mention Claude, AI, or any tool in commit messages.
+
+---
+
+## PR workflow
+
+- Branch off `main`. Name: `feat/<desc>`, `fix/<desc>`, `docs/<desc>`, `ci/<desc>`.
+- Target `mohu-org/mohu:main` from your fork.
+- DCO check runs on every PR — all commits must be signed.
+- `ci-pass` job is the required status check for merge.
+- Do not force-push after review comments land — add new commits.
+
+---
+
+## Do not do these
+
+- Do not add `println!` or `eprintln!` in library code — use `tracing`.
+- Do not use `unwrap()` or `expect()` outside tests and CLI entrypoints.
+- Do not add `[dev-dependencies]` that leak into workspace — scope them to the crate.
+- Do not create new crates without an RFC (see `docs/rfcs/`).
+- Do not edit `Cargo.lock` manually.
+- Do not commit with `--no-verify`.
+- Do not use `git add .` or `git add -A` — stage files explicitly.
+
+---
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `Cargo.toml` | Workspace root — all dep versions live here |
+| `deny.toml` | Allowed licenses, banned crates, advisory ignore list |
+| `clippy.toml` | Clippy thresholds |
+| `cliff.toml` | Changelog generation config (git-cliff) |
+| `CRATE_MAP.md` | Full module and public API surface per crate |
+| `.github/workflows/ci.yml` | 13-job CI pipeline |
+| `.github/workflows/release.yml` | Tag-triggered release + cross builds |
+| `.github/labeler.yml` | Auto-label rules for PRs |
+| `.github/auto_assign.yml` | Auto-reviewer assignment config |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,46 +1,277 @@
 # Contributing to mohu
 
+Thank you for your interest in contributing. This document covers everything you need to get from zero to a merged pull request.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Setting up the environment](#setting-up-the-environment)
+- [Workflow](#workflow)
+- [DCO sign-off](#dco-sign-off)
+- [Commit convention](#commit-convention)
+- [Branch naming](#branch-naming)
+- [Crate map](#crate-map)
+- [Running CI checks locally](#running-ci-checks-locally)
+- [Writing tests](#writing-tests)
+- [Writing benchmarks](#writing-benchmarks)
+- [Documentation](#documentation)
+- [PR checklist](#pr-checklist)
+
+---
+
 ## Prerequisites
 
-- Rust stable (see `rust-toolchain.toml`)
-- Python 3.10+ (for `mohu-py` development)
+| Tool | Minimum version | Install |
+|------|----------------|---------|
+| Rust stable | 1.85 (edition 2024) | `rustup update stable` |
+| Python | 3.10+ | for `mohu-py` only |
+| cargo-deny | latest | `cargo install cargo-deny` |
+| cargo-machete | latest | `cargo install cargo-machete` |
+
+Verify your setup:
+
+```sh
+rustc --version        # >= 1.85
+cargo clippy --version
+```
+
+---
+
+## Setting up the environment
+
+```sh
+# 1. Fork on GitHub, then clone your fork
+git clone https://github.com/<you>/mohu.git
+cd mohu
+
+# 2. Add upstream
+git remote add upstream https://github.com/mohu-org/mohu.git
+
+# 3. Keep fork in sync
+git fetch upstream
+git rebase upstream/main
+```
+
+---
 
 ## Workflow
 
-1. Fork and clone the repo
-2. Create a branch: `git checkout -b feat/your-feature`
-3. Make changes and verify: `make check`
-4. Open a PR using the template
+1. Sync with upstream: `git fetch upstream && git rebase upstream/main`
+2. Create a branch (see [Branch naming](#branch-naming))
+3. Make changes — run `cargo clippy` and `cargo test` before pushing
+4. Push to your fork: `git push origin <branch>`
+5. Open a PR against `mohu-org/mohu:main`
+6. Address review feedback; push follow-up commits to the same branch
+
+Do **not** force-push after a reviewer has left comments — add new commits instead.
+
+---
+
+## DCO sign-off
+
+Every commit **must** carry a `Signed-off-by` line. CI will reject PRs without it.
+
+```sh
+git commit -s -m "feat(core): add strided slice iterator"
+```
+
+This certifies you wrote the code and have the right to contribute it under the project license per the [Developer Certificate of Origin](https://developercertificate.org/).
+
+To fix a missing sign-off on the last commit:
+
+```sh
+git commit --amend -s --no-edit
+git push --force-with-lease origin <branch>
+```
+
+---
 
 ## Commit convention
 
-We use [Conventional Commits](https://www.conventionalcommits.org/):
+We use [Conventional Commits](https://www.conventionalcommits.org/). Subject line is **under 72 characters**, imperative mood, no trailing period.
 
 ```
-feat(core): add strided slice iterator
-fix(ops): correct broadcast shape inference for rank-0 arrays
-perf(linalg): use BLAS sgemm for f32 matmul
+feat(array): add strided slice iterator
+fix(ops): correct broadcast shape for rank-0 arrays
+perf(simd): use AVX2 path for f32 dot product
+refactor(buffer): split layout from allocation
+doc(error): document ErrorKind::is_recoverable
+test(stats): add property tests for median
+chore(deps): bump rand to 0.9.4
+ci: add MSRV check job
 ```
 
-Types: `feat`, `fix`, `perf`, `refactor`, `doc`, `test`, `chore`, `ci`
+| Type | When to use |
+|------|-------------|
+| `feat` | new user-visible functionality |
+| `fix` | bug fix |
+| `perf` | performance improvement |
+| `refactor` | no behaviour change, no new feature |
+| `doc` | documentation only |
+| `test` | adding or fixing tests |
+| `chore` | dependency bumps, tooling, config |
+| `ci` | changes to GitHub Actions workflows |
 
-Breaking changes: append `!` after the type — `feat(core)!: rename Array → NdArray`
+**Breaking changes:** append `!` after the type/scope — `feat(core)!: rename Array → NdArray`
 
-## Crate responsibilities
+---
+
+## Branch naming
+
+```
+feat/<short-description>        # new feature
+fix/<short-description>         # bug fix
+perf/<short-description>        # performance work
+refactor/<short-description>    # refactoring
+docs/<short-description>        # documentation
+ci/<short-description>          # CI/tooling changes
+```
+
+---
+
+## Crate map
+
+The workspace is layered — each layer only depends on layers below it.
+
+### Foundation
 
 | Crate | Owns |
-|---|---|
-| `mohu-core` | `NdArray`, `DType`, `Shape`, `Buffer`, `Layout`, `SliceInfo` |
-| `mohu-ops` | Broadcasting, element-wise arithmetic/cmp/logical, reductions |
-| `mohu-linalg` | matmul, LU, QR, SVD, Cholesky, norms, solvers, eigenvalues |
-| `mohu-stats` | Descriptive stats, distributions, random sampling |
-| `mohu-io` | `.npy`/`.npz`, CSV, Arrow IPC, memory-mapped arrays |
-| `mohu-py` | Python module, PyO3 bindings, NumPy buffer protocol |
+|-------|------|
+| `mohu-error` | Shared error types; zero-dependency base for every crate |
+| `mohu-dtype` | `DType` enum, scalar type traits, type promotion rules |
+| `mohu-buffer` | Raw buffer allocation, memory layout, stride arithmetic |
+| `mohu-array` | `NdArray<T>` — the core N-dimensional array type |
+| `mohu-core` | Re-export facade for the four crates above |
 
-## Running tests
+### Dispatch & protocol
+
+| Crate | Owns |
+|-------|------|
+| `mohu-simd` | AVX2 / AVX-512 / NEON SIMD kernel primitives |
+| `mohu-ufunc` | Universal-function protocol: broadcast, reduce, accumulate, outer |
+| `mohu-index` | Advanced indexing: fancy, boolean mask, take/put |
+
+### Compute
+
+| Crate | Owns |
+|-------|------|
+| `mohu-ops` | Element-wise arithmetic, comparison, logical, broadcasting |
+| `mohu-fft` | FFT, IFFT, RFFT, 2-D transforms |
+| `mohu-random` | PRNG engines and statistical distributions |
+| `mohu-special` | Special math: erf, gamma, beta, Bessel, … |
+| `mohu-stats` | Descriptive stats, hypothesis tests, sampling |
+
+### Data structure extensions
+
+| Crate | Owns |
+|-------|------|
+| `mohu-sparse` | COO / CSR / CSC sparse matrix formats |
+| `mohu-masked` | Masked arrays — null/invalid value propagation |
+
+### I/O & tooling
+
+| Crate | Owns |
+|-------|------|
+| `mohu-io` | `.npy`/`.npz`, CSV, Arrow IPC, memory-mapped files |
+| `mohu-testing` | Test fixtures, property-test helpers, array comparison utilities |
+
+---
+
+## Running CI checks locally
+
+Run these before pushing — CI runs all of them and will fail on any error.
 
 ```sh
-make test      # all workspace tests
-make lint      # clippy (warnings = errors)
-make bench     # benchmarks
+# Format
+cargo fmt --all
+
+# Lint (warnings = errors)
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+# Tests
+cargo test --workspace --all-features
+
+# Docs (doc warnings = errors)
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+
+# Dependency audit (advisories, licenses, bans, sources)
+cargo deny check
+
+# Unused dependencies
+cargo machete
+
+# Benchmarks compile check
+cargo bench --workspace --no-run --all-features
 ```
+
+---
+
+## Writing tests
+
+- Unit tests go in `#[cfg(test)]` modules inside the source file being tested.
+- Integration tests go in `crates/<name>/tests/`.
+- Property-based tests use `proptest` — see `mohu-testing::strategies` for pre-built generators.
+- Use `mohu-testing::approx` for floating-point array comparisons.
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mohu_testing::approx::assert_allclose;
+
+    #[test]
+    fn round_trip() {
+        // ...
+    }
+}
+```
+
+---
+
+## Writing benchmarks
+
+Benchmarks live in `benches/` at the workspace root and use the `criterion` harness.
+
+```sh
+cargo bench                          # run all benchmarks
+cargo bench -- array_ops             # run a specific group
+cargo bench --no-run --all-features  # verify benchmarks compile
+```
+
+---
+
+## Documentation
+
+- Every public item needs a doc comment.
+- Include at least one `# Example` section on non-trivial items.
+- Avoid restating what the name already says — document *why* and *when*.
+
+```rust
+/// Returns the total number of elements across all dimensions.
+///
+/// # Example
+///
+/// ```rust
+/// # use mohu_array::NdArray;
+/// let a = NdArray::<f32>::zeros(&[3, 4]);
+/// assert_eq!(a.size(), 12);
+/// ```
+pub fn size(&self) -> usize { ... }
+```
+
+---
+
+## PR checklist
+
+Before requesting review, confirm:
+
+- [ ] Branch rebased on `upstream/main`
+- [ ] All commits signed off (`git commit -s`)
+- [ ] `cargo fmt --all` — no diff
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
+- [ ] `cargo test --workspace --all-features` — passes
+- [ ] New public APIs have doc comments with examples
+- [ ] `CHANGELOG.md` entry added for user-visible changes
+- [ ] No `TODO`, `unimplemented!()`, or stub functions left in completed code


### PR DESCRIPTION
## Summary

- Adds DCO sign-off requirement and how to fix missing sign-offs
- Documents all 17 workspace crates with layered dependency map
- Adds full local CI reproduction commands (fmt, clippy, test, deny, machete, bench)
- Adds branch naming conventions, PR checklist, testing and benchmark guidance
- Replaces stub `make` commands with actual `cargo` invocations that match CI

## Test plan

- [ ] Verify all commands in the doc match the actual CI workflow jobs
- [ ] Read through as a first-time contributor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Overhauled contribution guide with expanded prerequisites, workflow/PR guidance, commit/DCO rules, detailed crate map, local CI commands, testing/benchmarking/docs guidance, and an explicit PR checklist.
  * Added new CLAUDE.md and AGENTS.md with project-specific contributor rules, coding conventions, and agent operating checklists.
* **Chores**
  * Updated PR automation workflow to improve reviewer assignment and PR summary generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->