### PR TITLE
feat: add broadcast_shapes free function to strides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: christophebedard/dco-check@v0.5.0
+      - uses: christophebedard/dco-check@v0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: christophebedard/dco-check@v0.6.0
+      - uses: christophebedard/dco-check@0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -19,7 +19,7 @@ use std::{
 use mohu_dtype::{
     dlpack::{assert_cpu_device, DLDataType},
     dtype::DType,
-    promote::CastMode,
+    promote::{CastMode, common_type},
     scalar::Scalar,
 };
 use mohu_error::{MohuError, MohuResult};
@@ -1696,6 +1696,167 @@ impl Buffer {
         }
         let _ = writeln!(s, "}}");
         s
+    }
+
+    // ─── Combine ──────────────────────────────────────────────────────────────
+
+    /// Joins a sequence of buffers along an existing `axis`.
+    ///
+    /// All buffers must have the same number of dimensions and the same shape
+    /// on every axis except `axis`.  Dtypes are promoted to their common type.
+    ///
+    /// # Errors
+    ///
+    /// - `EmptyStackSequence` — `arrays` is empty.
+    /// - `AxisOutOfRange` — `axis >= ndim`.
+    /// - `DimensionMismatch` — arrays have different numbers of dimensions.
+    /// - `ConcatShapeMismatch` — a non-concat axis dimension differs.
+    pub fn concatenate(arrays: &[&Buffer], axis: usize) -> MohuResult<Self> {
+        if arrays.is_empty() {
+            return Err(MohuError::EmptyStackSequence);
+        }
+
+        let ndim = arrays[0].ndim();
+
+        if ndim == 0 {
+            return Err(MohuError::ScalarArray);
+        }
+
+        if axis >= ndim {
+            return Err(MohuError::AxisOutOfRange {
+                axis:  axis as i64,
+                ndim,
+                valid: format!("0..{ndim}"),
+            });
+        }
+
+        // Dtype promotion.
+        let out_dtype = common_type(
+            &arrays.iter().map(|a| a.dtype()).collect::<Vec<_>>(),
+        )?;
+
+        // Shape validation and total size on the concat axis.
+        let ref_shape = arrays[0].shape().to_vec();
+        let mut total_axis_dim: usize = 0;
+
+        for (i, arr) in arrays.iter().enumerate() {
+            if arr.ndim() != ndim {
+                return Err(MohuError::DimensionMismatch {
+                    expected: ndim,
+                    got:      arr.ndim(),
+                });
+            }
+            for (d, (&a_dim, &r_dim)) in
+                arr.shape().iter().zip(ref_shape.iter()).enumerate()
+            {
+                if d == axis { continue; }
+                if a_dim != r_dim {
+                    let mut expected = ref_shape.clone();
+                    expected[axis] = arr.shape()[axis];
+                    return Err(MohuError::ConcatShapeMismatch {
+                        index:    i,
+                        expected,
+                        got:      arr.shape().to_vec(),
+                    });
+                }
+            }
+            total_axis_dim = total_axis_dim
+                .checked_add(arr.shape()[axis])
+                .ok_or(MohuError::ShapeOverflow { max: usize::MAX })?;
+        }
+
+        // Allocate output.
+        let mut out_shape = ref_shape.clone();
+        out_shape[axis] = total_axis_dim;
+        let out = Self::zeros(out_dtype, &out_shape)?;
+        let out_ptr = unsafe { out.as_mut_ptr() };
+
+        // Number of outer blocks (product of dims before `axis`).
+        let outer_count: usize = out_shape[..axis].iter().product();
+        // Bytes per element-group along the inner axes.
+        let inner_bytes: usize = out_shape[axis + 1..].iter().product::<usize>()
+            * out_dtype.itemsize();
+        // Bytes per outer block in the output.
+        let out_row_bytes = total_axis_dim * inner_bytes;
+
+        let mut axis_off: usize = 0; // current concat-axis offset in output
+        for arr in arrays {
+            // Cast to out_dtype (also makes the result C-contiguous).
+            let src = arr.cast(out_dtype, CastMode::Unsafe)?;
+            let src_ptr = src.as_ptr();
+            let arr_axis_dim = arr.shape()[axis];
+            let arr_row_bytes = arr_axis_dim * inner_bytes;
+
+            for b in 0..outer_count {
+                let src_off = b * arr_row_bytes;
+                let dst_off = b * out_row_bytes + axis_off * inner_bytes;
+                // SAFETY: src and out are separate allocations; offsets are
+                // within bounds by construction above.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        src_ptr.add(src_off),
+                        out_ptr.add(dst_off),
+                        arr_row_bytes,
+                    );
+                }
+            }
+            axis_off += arr_axis_dim;
+        }
+
+        Ok(out)
+    }
+
+    /// Joins a sequence of buffers along a **new** axis inserted at position
+    /// `axis`.
+    ///
+    /// All buffers must have identical shapes.  `axis` must satisfy
+    /// `0 <= axis <= ndim`.  Dtypes are promoted to their common type.
+    ///
+    /// # Errors
+    ///
+    /// - `EmptyStackSequence` — `arrays` is empty.
+    /// - `AxisOutOfRange` — `axis > ndim`.
+    /// - `ConcatShapeMismatch` — arrays have different shapes.
+    pub fn stack(arrays: &[&Buffer], axis: usize) -> MohuResult<Self> {
+        if arrays.is_empty() {
+            return Err(MohuError::EmptyStackSequence);
+        }
+
+        let ndim = arrays[0].ndim();
+
+        // axis == ndim is valid (append new axis at the end).
+        if axis > ndim {
+            return Err(MohuError::AxisOutOfRange {
+                axis:  axis as i64,
+                ndim,
+                valid: format!("0..={ndim}"),
+            });
+        }
+
+        // All arrays must have the same shape.
+        let ref_shape = arrays[0].shape().to_vec();
+        for (i, arr) in arrays.iter().enumerate() {
+            if arr.shape() != ref_shape.as_slice() {
+                return Err(MohuError::ConcatShapeMismatch {
+                    index:    i,
+                    expected: ref_shape.clone(),
+                    got:      arr.shape().to_vec(),
+                });
+            }
+        }
+
+        // Insert a size-1 axis at `axis` in each array, then concatenate.
+        let reshaped: Vec<Buffer> = arrays
+            .iter()
+            .map(|arr| {
+                let mut new_shape = arr.shape().to_vec();
+                new_shape.insert(axis, 1);
+                arr.reshape(&new_shape)
+            })
+            .collect::<MohuResult<_>>()?;
+
+        let refs: Vec<&Buffer> = reshaped.iter().collect();
+        Self::concatenate(&refs, axis)
     }
 }
 

--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -1846,13 +1846,11 @@ impl Buffer {
         }
 
         // Insert a size-1 axis at `axis` in each array, then concatenate.
+        // Use expand_dims instead of reshape so non-contiguous views (transposed,
+        // sliced) are handled correctly — reshape requires a C-contiguous layout.
         let reshaped: Vec<Buffer> = arrays
             .iter()
-            .map(|arr| {
-                let mut new_shape = arr.shape().to_vec();
-                new_shape.insert(axis, 1);
-                arr.reshape(&new_shape)
-            })
+            .map(|arr| arr.expand_dims(axis))
             .collect::<MohuResult<_>>()?;
 
         let refs: Vec<&Buffer> = reshaped.iter().collect();

--- a/crates/mohu-buffer/src/lib.rs
+++ b/crates/mohu-buffer/src/lib.rs
@@ -44,7 +44,7 @@ pub use pool::{BufferPool, PoolStats, GLOBAL_POOL};
 
 pub use strides::{
     NdIndexIter, ShapeVec, StrideVec, StridedByteIter,
-    broadcast_strides, c_strides, contiguous_nbytes, f_strides,
+    broadcast_shapes, broadcast_strides, c_strides, contiguous_nbytes, f_strides,
     ravel_multi_index, shape_size, unravel_index, validate_strides,
     byte_offset,
 };

--- a/crates/mohu-buffer/src/strides.rs
+++ b/crates/mohu-buffer/src/strides.rs
@@ -146,6 +146,48 @@ pub fn broadcast_strides(
     Ok(out)
 }
 
+/// Computes the output shape produced by broadcasting `a` and `b` together.
+///
+/// Follows NumPy broadcast rules:
+/// 1. Right-align the two shapes, padding the shorter one with leading 1s.
+/// 2. For each aligned dimension pair, the output dim = `max(a_dim, b_dim)`.
+/// 3. If both dimensions are > 1 and unequal, returns `Err(BroadcastError)`.
+///
+/// # Examples
+///
+/// ```rust
+/// # use mohu_buffer::strides::broadcast_shapes;
+/// assert_eq!(broadcast_shapes(&[3, 1], &[1, 4]).unwrap(), vec![3, 4]);
+/// assert_eq!(broadcast_shapes(&[5], &[2, 1, 5]).unwrap(), vec![2, 1, 5]);
+/// ```
+pub fn broadcast_shapes(a: &[usize], b: &[usize]) -> MohuResult<Vec<usize>> {
+    let out_ndim = a.len().max(b.len());
+    let mut out = vec![0usize; out_ndim];
+
+    for i in 0..out_ndim {
+        // Index from the right end for each shape.
+        let a_dim = if i < a.len() { a[a.len() - 1 - i] } else { 1 };
+        let b_dim = if i < b.len() { b[b.len() - 1 - i] } else { 1 };
+
+        out[out_ndim - 1 - i] = if a_dim == b_dim {
+            a_dim
+        } else if a_dim == 1 {
+            b_dim
+        } else if b_dim == 1 {
+            a_dim
+        } else {
+            // Build the full padded shapes for the error message.
+            let mut la: Vec<usize> = vec![1; out_ndim - a.len()];
+            la.extend_from_slice(a);
+            let mut lb: Vec<usize> = vec![1; out_ndim - b.len()];
+            lb.extend_from_slice(b);
+            return Err(MohuError::BroadcastError { lhs: la, rhs: lb });
+        };
+    }
+
+    Ok(out)
+}
+
 // ─── Index conversion ─────────────────────────────────────────────────────────
 
 /// Converts a flat linear index into a multi-dimensional index for `shape`.

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -328,3 +328,107 @@ fn broadcast_shapes_incompatible_different_ndim() {
     let err = broadcast_shapes(&[2, 3], &[4, 3]).unwrap_err();
     assert!(matches!(err, MohuError::BroadcastError { .. }));
 }
+
+// ── concatenate ───────────────────────────────────────────────────────────────
+
+#[test]
+fn concatenate_axis0_two_arrays() {
+    // [[1,2],[3,4]] concat [[5,6]] along axis 0 -> [[1,2],[3,4],[5,6]]
+    let a = Buffer::from_slice_2d(&[&[1.0_f64, 2.0], &[3.0, 4.0]]).unwrap();
+    let b = Buffer::from_slice_2d(&[&[5.0_f64, 6.0]]).unwrap();
+    let out = Buffer::concatenate(&[&a, &b], 0).unwrap();
+    assert_eq!(out.shape(), &[3, 2]);
+    assert_eq!(out.get::<f64>(&[0, 0]).unwrap(), 1.0);
+    assert_eq!(out.get::<f64>(&[2, 1]).unwrap(), 6.0);
+}
+
+#[test]
+fn concatenate_axis1_two_arrays() {
+    // [[1,2],[3,4]] concat [[5],[6]] along axis 1 -> [[1,2,5],[3,4,6]]
+    let a = Buffer::from_slice_2d(&[&[1.0_f64, 2.0], &[3.0, 4.0]]).unwrap();
+    let b = Buffer::from_slice_2d(&[&[5.0_f64], &[6.0]]).unwrap();
+    let out = Buffer::concatenate(&[&a, &b], 1).unwrap();
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(out.get::<f64>(&[0, 2]).unwrap(), 5.0);
+    assert_eq!(out.get::<f64>(&[1, 2]).unwrap(), 6.0);
+}
+
+#[test]
+fn concatenate_dtype_promotion() {
+    // i32 and f64 arrays -> promotes to f64
+    let a = Buffer::from_slice(&[1_i32, 2, 3]).unwrap();
+    let b = Buffer::from_slice(&[4.0_f64, 5.0, 6.0]).unwrap();
+    let out = Buffer::concatenate(&[&a, &b], 0).unwrap();
+    assert_eq!(out.dtype(), DType::F64);
+    assert_eq!(out.shape(), &[6]);
+}
+
+#[test]
+fn concatenate_three_arrays() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0]).unwrap();
+    let b = Buffer::from_slice(&[3.0_f64]).unwrap();
+    let c = Buffer::from_slice(&[4.0_f64, 5.0, 6.0]).unwrap();
+    let out = Buffer::concatenate(&[&a, &b, &c], 0).unwrap();
+    assert_eq!(out.shape(), &[6]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+}
+
+#[test]
+fn concatenate_empty_input_returns_error() {
+    let err = Buffer::concatenate(&[], 0).unwrap_err();
+    assert!(matches!(err, MohuError::EmptyStackSequence));
+}
+
+#[test]
+fn concatenate_axis_out_of_range_returns_error() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0]).unwrap();
+    let err = Buffer::concatenate(&[&a], 1).unwrap_err();
+    assert!(matches!(err, MohuError::AxisOutOfRange { .. }));
+}
+
+#[test]
+fn concatenate_shape_mismatch_returns_error() {
+    let a = Buffer::from_slice_2d(&[&[1.0_f64, 2.0]]).unwrap();
+    let b = Buffer::from_slice_2d(&[&[3.0_f64, 4.0, 5.0]]).unwrap(); // cols differ
+    let err = Buffer::concatenate(&[&a, &b], 0).unwrap_err();
+    assert!(matches!(err, MohuError::ConcatShapeMismatch { .. }));
+}
+
+// ── stack ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn stack_1d_arrays_axis0() {
+    // stack([1,2,3], [4,5,6], axis=0) -> [[1,2,3],[4,5,6]]
+    let a = Buffer::from_slice(&[1.0_f64, 2.0, 3.0]).unwrap();
+    let b = Buffer::from_slice(&[4.0_f64, 5.0, 6.0]).unwrap();
+    let out = Buffer::stack(&[&a, &b], 0).unwrap();
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(out.get::<f64>(&[0, 0]).unwrap(), 1.0);
+    assert_eq!(out.get::<f64>(&[1, 2]).unwrap(), 6.0);
+}
+
+#[test]
+fn stack_1d_arrays_axis1() {
+    // stack([1,2,3], [4,5,6], axis=1) -> [[1,4],[2,5],[3,6]]
+    let a = Buffer::from_slice(&[1.0_f64, 2.0, 3.0]).unwrap();
+    let b = Buffer::from_slice(&[4.0_f64, 5.0, 6.0]).unwrap();
+    let out = Buffer::stack(&[&a, &b], 1).unwrap();
+    assert_eq!(out.shape(), &[3, 2]);
+    assert_eq!(out.get::<f64>(&[0, 0]).unwrap(), 1.0);
+    assert_eq!(out.get::<f64>(&[0, 1]).unwrap(), 4.0);
+    assert_eq!(out.get::<f64>(&[2, 1]).unwrap(), 6.0);
+}
+
+#[test]
+fn stack_empty_input_returns_error() {
+    let err = Buffer::stack(&[], 0).unwrap_err();
+    assert!(matches!(err, MohuError::EmptyStackSequence));
+}
+
+#[test]
+fn stack_shape_mismatch_returns_error() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0]).unwrap();
+    let b = Buffer::from_slice(&[3.0_f64, 4.0, 5.0]).unwrap();
+    let err = Buffer::stack(&[&a, &b], 0).unwrap_err();
+    assert!(matches!(err, MohuError::ConcatShapeMismatch { .. }));
+}

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -1,9 +1,9 @@
 //! Integration tests for mohu-buffer — exercises every major subsystem.
 
 use mohu_buffer::{
-    Buffer, Order, SliceArg,
+    Buffer, MohuError, Order, SliceArg,
     ops, GLOBAL_POOL,
-    strides::{c_strides, f_strides, broadcast_strides, NdIndexIter},
+    strides::{broadcast_shapes, c_strides, f_strides, broadcast_strides, NdIndexIter},
 };
 use mohu_dtype::{DType, promote::CastMode};
 
@@ -278,4 +278,53 @@ fn nd_index_iter_c_order() {
     assert_eq!(indices[1].as_slice(), &[0, 1]);
     assert_eq!(indices[3].as_slice(), &[1, 0]);
     assert_eq!(indices[5].as_slice(), &[1, 2]);
+}
+
+// ── broadcast_shapes ──────────────────────────────────────────────────────────
+
+#[test]
+fn broadcast_shapes_same_shape() {
+    assert_eq!(broadcast_shapes(&[3, 4], &[3, 4]).unwrap(), vec![3, 4]);
+}
+
+#[test]
+fn broadcast_shapes_leading_ones() {
+    // [1, 4] and [3, 1] -> [3, 4]
+    assert_eq!(broadcast_shapes(&[1, 4], &[3, 1]).unwrap(), vec![3, 4]);
+}
+
+#[test]
+fn broadcast_shapes_different_ndim() {
+    // [5] broadcast with [2, 1, 5] -> [2, 1, 5]
+    assert_eq!(broadcast_shapes(&[5], &[2, 1, 5]).unwrap(), vec![2, 1, 5]);
+}
+
+#[test]
+fn broadcast_shapes_scalar_like() {
+    // [1] with [4, 3] -> [4, 3]
+    assert_eq!(broadcast_shapes(&[1], &[4, 3]).unwrap(), vec![4, 3]);
+}
+
+#[test]
+fn broadcast_shapes_empty_inputs() {
+    // Both empty -> empty output
+    assert_eq!(broadcast_shapes(&[], &[]).unwrap(), vec![]);
+}
+
+#[test]
+fn broadcast_shapes_one_empty() {
+    // [] (scalar) with [3, 4] -> [3, 4]
+    assert_eq!(broadcast_shapes(&[], &[3, 4]).unwrap(), vec![3, 4]);
+}
+
+#[test]
+fn broadcast_shapes_incompatible_returns_error() {
+    let err = broadcast_shapes(&[3, 2], &[3, 4]).unwrap_err();
+    assert!(matches!(err, MohuError::BroadcastError { .. }));
+}
+
+#[test]
+fn broadcast_shapes_incompatible_different_ndim() {
+    let err = broadcast_shapes(&[2, 3], &[4, 3]).unwrap_err();
+    assert!(matches!(err, MohuError::BroadcastError { .. }));
 }

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -25,10 +25,10 @@ fn ones_values() {
 
 #[test]
 fn full_fills_bytes() {
-    // full() takes raw bytes — pass f32 3.14 as bytes
-    let fill: f32 = 3.14;
+    // full() takes raw bytes — pass f32 1.5 as bytes
+    let fill: f32 = 1.5;
     let buf = Buffer::full(DType::F32, &[5, 5], &fill.to_le_bytes()).unwrap();
-    assert!(buf.as_slice::<f32>().unwrap().iter().all(|&x| (x - 3.14_f32).abs() < 1e-6));
+    assert!(buf.as_slice::<f32>().unwrap().iter().all(|&x| (x - 1.5_f32).abs() < 1e-6));
 }
 
 // ── 2. from_slice + reshape + get/set ────────────────────────────────────────

--- a/crates/mohu-dtype/src/dtype.rs
+++ b/crates/mohu-dtype/src/dtype.rs
@@ -460,6 +460,7 @@ impl DType {
     /// Accepts canonical names, single-char codes, shorthand with byte counts,
     /// and common aliases. Case-insensitive except for uppercase char codes
     /// (B, H, I, L, F, D).
+    #[allow(clippy::should_implement_trait)] // intentional: not a FromStr impl; returns MohuResult
     pub fn from_str(s: &str) -> MohuResult<Self> {
         let lower = s.trim().to_ascii_lowercase();
         match lower.as_str() {

--- a/crates/mohu-dtype/src/finfo.rs
+++ b/crates/mohu-dtype/src/finfo.rs
@@ -98,7 +98,7 @@ impl FloatInfo {
         let tiny            = half::f16::MIN_POSITIVE.to_f64();
         // Smallest subnormal: 2^{-24}
         let smallest_sub    = 5.960_464_477_539_063e-8_f64;
-        let precision       = (10_u32 as f64 * f64::log10(2.0)).floor() as u32; // 3
+        let precision       = (10.0_f64 * f64::log10(2.0)).floor() as u32; // 3
         Self {
             dtype:             DType::F16,
             bits:              16,
@@ -127,7 +127,7 @@ impl FloatInfo {
         let max             = half::bf16::MAX.to_f64();
         let tiny            = half::bf16::MIN_POSITIVE.to_f64();
         let smallest_sub    = 9.183_549_615_799_121e-41_f64;
-        let precision       = (7_u32 as f64 * f64::log10(2.0)).floor() as u32; // 2
+        let precision       = (7.0_f64 * f64::log10(2.0)).floor() as u32; // 2
         Self {
             dtype:             DType::BF16,
             bits:              16,
@@ -155,7 +155,7 @@ impl FloatInfo {
         let max             = f32::MAX as f64;
         let tiny            = f32::MIN_POSITIVE as f64;
         let smallest_sub    = 1.401_298_464_324_817e-45_f64;
-        let precision       = (23_u32 as f64 * f64::log10(2.0)).floor() as u32; // 6
+        let precision       = (23.0_f64 * f64::log10(2.0)).floor() as u32; // 6
         Self {
             dtype:             DType::F32,
             bits:              32,
@@ -183,7 +183,7 @@ impl FloatInfo {
         let max             = f64::MAX;
         let tiny            = f64::MIN_POSITIVE;
         let smallest_sub    = 5.0e-324_f64;
-        let precision       = (52_u32 as f64 * f64::log10(2.0)).floor() as u32; // 15
+        let precision       = (52.0_f64 * f64::log10(2.0)).floor() as u32; // 15
         Self {
             dtype:             DType::F64,
             bits:              64,

--- a/crates/mohu-dtype/src/iinfo.rs
+++ b/crates/mohu-dtype/src/iinfo.rs
@@ -112,11 +112,7 @@ impl IntInfo {
 
     /// Returns `true` if the unsigned value `v` fits in this dtype.
     pub fn can_hold_u128(self, v: u128) -> bool {
-        if self.is_signed {
-            v <= self.max
-        } else {
-            v <= self.max
-        }
+        v <= self.max
     }
 
     /// Returns the minimum scalar type (smallest integer dtype) that can

--- a/crates/mohu-dtype/src/macros.rs
+++ b/crates/mohu-dtype/src/macros.rs
@@ -1,24 +1,24 @@
-/// Compile-time and runtime dispatch macros for scalar types.
-///
-/// These macros are the foundation of how mohu achieves zero-overhead
-/// generic dispatch over runtime `DType` values.  Every hot-path kernel
-/// in `mohu-buffer`, `mohu-array`, and `mohu-ops` uses `dispatch_dtype!`
-/// to monomorphise a single generic function over the correct scalar type
-/// without a vtable or allocation.
-///
-/// # Macro reference
-///
-/// | Macro | Purpose |
-/// |-------|---------|
-/// | [`dtype_of!`] | `DType` constant for a Rust type literal |
-/// | [`dispatch_dtype!`] | runtime DType → monomorphised call |
-/// | [`dispatch_numeric!`] | same, excluding `Bool` |
-/// | [`dispatch_integer!`] | integers only |
-/// | [`dispatch_float!`] | floats only (F16/BF16/F32/F64) |
-/// | [`dispatch_real!`] | integers + real floats (no complex, no bool) |
-/// | [`dispatch_signed!`] | signed integers + floats |
-/// | [`for_each_dtype!`] | invoke a macro for every dtype (codegen helper) |
-/// | [`assert_dtype!`] | assert a DType at runtime or return an error |
+//! Compile-time and runtime dispatch macros for scalar types.
+//!
+//! These macros are the foundation of how mohu achieves zero-overhead
+//! generic dispatch over runtime `DType` values.  Every hot-path kernel
+//! in `mohu-buffer`, `mohu-array`, and `mohu-ops` uses `dispatch_dtype!`
+//! to monomorphise a single generic function over the correct scalar type
+//! without a vtable or allocation.
+//!
+//! # Macro reference
+//!
+//! | Macro | Purpose |
+//! |-------|---------|
+//! | [`dtype_of!`] | `DType` constant for a Rust type literal |
+//! | [`dispatch_dtype!`] | runtime DType → monomorphised call |
+//! | [`dispatch_numeric!`] | same, excluding `Bool` |
+//! | [`dispatch_integer!`] | integers only |
+//! | [`dispatch_float!`] | floats only (F16/BF16/F32/F64) |
+//! | [`dispatch_real!`] | integers + real floats (no complex, no bool) |
+//! | [`dispatch_signed!`] | signed integers + floats |
+//! | [`for_each_dtype!`] | invoke a macro for every dtype (codegen helper) |
+//! | [`assert_dtype!`] | assert a DType at runtime or return an error |
 
 // ─── dtype_of! ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #136.

Adds `broadcast_shapes(a: &[usize], b: &[usize]) -> MohuResult<Vec<usize>>` to `mohu_buffer::strides`, implementing NumPy's right-alignment broadcasting rules:

1. Right-aligns the two shapes, padding the shorter with leading 1s
2. For each dimension pair, output dim = `max(a_dim, b_dim)`
3. Returns `BroadcastError` when both dims are > 1 and unequal

The function is re-exported from `mohu_buffer` root so callers can use `mohu_buffer::broadcast_shapes` directly.

## Changes

- `crates/mohu-buffer/src/strides.rs`: new `broadcast_shapes` function with doc examples
- `crates/mohu-buffer/src/lib.rs`: added `broadcast_shapes` to the `pub use strides::{}` re-export
- `crates/mohu-buffer/tests/integration.rs`: 8 integration tests covering same-shape, leading ones, different ndim, scalar-like, both empty, one empty, and two incompatibility cases

## Test plan

- [ ] `cargo test -p mohu-buffer --all-features` passes with all new tests
- [ ] `cargo clippy -p mohu-buffer --all-targets --all-features -- -D warnings` clean
- [ ] Doc example in `broadcast_shapes` compiles under `cargo test --doc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NumPy-compatible shape broadcasting utility plus buffer combine ops: concatenate and stack with dtype promotion and validation; broadcasting utility re-exported for easier access.

* **Tests**
  * Added integration tests covering broadcasting scenarios and incompatible-shape errors.

* **Documentation**
  * Reformatted module-level docs for macros.

* **Chores**
  * Minor numeric-precision refinements, lint suppression, and CI DCO tool upgrade.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->