### PR TITLE
feat: add Buffer::concatenate and Buffer::stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: christophebedard/dco-check@v0.5.0
+      - uses: christophebedard/dco-check@v0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: christophebedard/dco-check@v0.6.0
+      - uses: christophebedard/dco-check@0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -19,7 +19,7 @@ use std::{
 use mohu_dtype::{
     dlpack::{assert_cpu_device, DLDataType},
     dtype::DType,
-    promote::CastMode,
+    promote::{CastMode, common_type},
     scalar::Scalar,
 };
 use mohu_error::{MohuError, MohuResult};
@@ -1696,6 +1696,167 @@ impl Buffer {
         }
         let _ = writeln!(s, "}}");
         s
+    }
+
+    // ─── Combine ──────────────────────────────────────────────────────────────
+
+    /// Joins a sequence of buffers along an existing `axis`.
+    ///
+    /// All buffers must have the same number of dimensions and the same shape
+    /// on every axis except `axis`.  Dtypes are promoted to their common type.
+    ///
+    /// # Errors
+    ///
+    /// - `EmptyStackSequence` — `arrays` is empty.
+    /// - `AxisOutOfRange` — `axis >= ndim`.
+    /// - `DimensionMismatch` — arrays have different numbers of dimensions.
+    /// - `ConcatShapeMismatch` — a non-concat axis dimension differs.
+    pub fn concatenate(arrays: &[&Buffer], axis: usize) -> MohuResult<Self> {
+        if arrays.is_empty() {
+            return Err(MohuError::EmptyStackSequence);
+        }
+
+        let ndim = arrays[0].ndim();
+
+        if ndim == 0 {
+            return Err(MohuError::ScalarArray);
+        }
+
+        if axis >= ndim {
+            return Err(MohuError::AxisOutOfRange {
+                axis:  axis as i64,
+                ndim,
+                valid: format!("0..{ndim}"),
+            });
+        }
+
+        // Dtype promotion.
+        let out_dtype = common_type(
+            &arrays.iter().map(|a| a.dtype()).collect::<Vec<_>>(),
+        )?;
+
+        // Shape validation and total size on the concat axis.
+        let ref_shape = arrays[0].shape().to_vec();
+        let mut total_axis_dim: usize = 0;
+
+        for (i, arr) in arrays.iter().enumerate() {
+            if arr.ndim() != ndim {
+                return Err(MohuError::DimensionMismatch {
+                    expected: ndim,
+                    got:      arr.ndim(),
+                });
+            }
+            for (d, (&a_dim, &r_dim)) in
+                arr.shape().iter().zip(ref_shape.iter()).enumerate()
+            {
+                if d == axis { continue; }
+                if a_dim != r_dim {
+                    let mut expected = ref_shape.clone();
+                    expected[axis] = arr.shape()[axis];
+                    return Err(MohuError::ConcatShapeMismatch {
+                        index:    i,
+                        expected,
+                        got:      arr.shape().to_vec(),
+                    });
+                }
+            }
+            total_axis_dim = total_axis_dim
+                .checked_add(arr.shape()[axis])
+                .ok_or(MohuError::ShapeOverflow { max: usize::MAX })?;
+        }
+
+        // Allocate output.
+        let mut out_shape = ref_shape.clone();
+        out_shape[axis] = total_axis_dim;
+        let out = Self::zeros(out_dtype, &out_shape)?;
+        let out_ptr = unsafe { out.as_mut_ptr() };
+
+        // Number of outer blocks (product of dims before `axis`).
+        let outer_count: usize = out_shape[..axis].iter().product();
+        // Bytes per element-group along the inner axes.
+        let inner_bytes: usize = out_shape[axis + 1..].iter().product::<usize>()
+            * out_dtype.itemsize();
+        // Bytes per outer block in the output.
+        let out_row_bytes = total_axis_dim * inner_bytes;
+
+        let mut axis_off: usize = 0; // current concat-axis offset in output
+        for arr in arrays {
+            // Cast to out_dtype (also makes the result C-contiguous).
+            let src = arr.cast(out_dtype, CastMode::Unsafe)?;
+            let src_ptr = src.as_ptr();
+            let arr_axis_dim = arr.shape()[axis];
+            let arr_row_bytes = arr_axis_dim * inner_bytes;
+
+            for b in 0..outer_count {
+                let src_off = b * arr_row_bytes;
+                let dst_off = b * out_row_bytes + axis_off * inner_bytes;
+                // SAFETY: src and out are separate allocations; offsets are
+                // within bounds by construction above.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        src_ptr.add(src_off),
+                        out_ptr.add(dst_off),
+                        arr_row_bytes,
+                    );
+                }
+            }
+            axis_off += arr_axis_dim;
+        }
+
+        Ok(out)
+    }
+
+    /// Joins a sequence of buffers along a **new** axis inserted at position
+    /// `axis`.
+    ///
+    /// All buffers must have identical shapes.  `axis` must satisfy
+    /// `0 <= axis <= ndim`.  Dtypes are promoted to their common type.
+    ///
+    /// # Errors
+    ///
+    /// - `EmptyStackSequence` — `arrays` is empty.
+    /// - `AxisOutOfRange` — `axis > ndim`.
+    /// - `ConcatShapeMismatch` — arrays have different shapes.
+    pub fn stack(arrays: &[&Buffer], axis: usize) -> MohuResult<Self> {
+        if arrays.is_empty() {
+            return Err(MohuError::EmptyStackSequence);
+        }
+
+        let ndim = arrays[0].ndim();
+
+        // axis == ndim is valid (append new axis at the end).
+        if axis > ndim {
+            return Err(MohuError::AxisOutOfRange {
+                axis:  axis as i64,
+                ndim,
+                valid: format!("0..={ndim}"),
+            });
+        }
+
+        // All arrays must have the same shape.
+        let ref_shape = arrays[0].shape().to_vec();
+        for (i, arr) in arrays.iter().enumerate() {
+            if arr.shape() != ref_shape.as_slice() {
+                return Err(MohuError::ConcatShapeMismatch {
+                    index:    i,
+                    expected: ref_shape.clone(),
+                    got:      arr.shape().to_vec(),
+                });
+            }
+        }
+
+        // Insert a size-1 axis at `axis` in each array, then concatenate.
+        let reshaped: Vec<Buffer> = arrays
+            .iter()
+            .map(|arr| {
+                let mut new_shape = arr.shape().to_vec();
+                new_shape.insert(axis, 1);
+                arr.reshape(&new_shape)
+            })
+            .collect::<MohuResult<_>>()?;
+
+        let refs: Vec<&Buffer> = reshaped.iter().collect();
+        Self::concatenate(&refs, axis)
     }
 }
 

--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -1846,13 +1846,11 @@ impl Buffer {
         }
 
         // Insert a size-1 axis at `axis` in each array, then concatenate.
+        // Use expand_dims instead of reshape so non-contiguous views (transposed,
+        // sliced) are handled correctly; reshape requires C-contiguous layout.
         let reshaped: Vec<Buffer> = arrays
             .iter()
-            .map(|arr| {
-                let mut new_shape = arr.shape().to_vec();
-                new_shape.insert(axis, 1);
-                arr.reshape(&new_shape)
-            })
+            .map(|arr| arr.expand_dims(axis))
             .collect::<MohuResult<_>>()?;
 
         let refs: Vec<&Buffer> = reshaped.iter().collect();

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -25,10 +25,10 @@ fn ones_values() {
 
 #[test]
 fn full_fills_bytes() {
-    // full() takes raw bytes — pass f32 3.14 as bytes
-    let fill: f32 = 3.14;
+    // full() takes raw bytes — pass f32 1.5 as bytes
+    let fill: f32 = 1.5;
     let buf = Buffer::full(DType::F32, &[5, 5], &fill.to_le_bytes()).unwrap();
-    assert!(buf.as_slice::<f32>().unwrap().iter().all(|&x| (x - 3.14_f32).abs() < 1e-6));
+    assert!(buf.as_slice::<f32>().unwrap().iter().all(|&x| (x - 1.5_f32).abs() < 1e-6));
 }
 
 // ── 2. from_slice + reshape + get/set ────────────────────────────────────────

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -1,7 +1,7 @@
 //! Integration tests for mohu-buffer — exercises every major subsystem.
 
 use mohu_buffer::{
-    Buffer, Order, SliceArg,
+    Buffer, MohuError, Order, SliceArg,
     ops, GLOBAL_POOL,
     strides::{c_strides, f_strides, broadcast_strides, NdIndexIter},
 };
@@ -278,4 +278,103 @@ fn nd_index_iter_c_order() {
     assert_eq!(indices[1].as_slice(), &[0, 1]);
     assert_eq!(indices[3].as_slice(), &[1, 0]);
     assert_eq!(indices[5].as_slice(), &[1, 2]);
+}
+
+// ── concatenate ───────────────────────────────────────────────────────────────
+
+#[test]
+fn concatenate_axis0_two_arrays() {
+    let a = Buffer::from_slice_2d(&[&[1.0_f64, 2.0], &[3.0, 4.0]]).unwrap();
+    let b = Buffer::from_slice_2d(&[&[5.0_f64, 6.0]]).unwrap();
+    let out = Buffer::concatenate(&[&a, &b], 0).unwrap();
+    assert_eq!(out.shape(), &[3, 2]);
+    assert_eq!(out.get::<f64>(&[0, 0]).unwrap(), 1.0);
+    assert_eq!(out.get::<f64>(&[2, 1]).unwrap(), 6.0);
+}
+
+#[test]
+fn concatenate_axis1_two_arrays() {
+    let a = Buffer::from_slice_2d(&[&[1.0_f64, 2.0], &[3.0, 4.0]]).unwrap();
+    let b = Buffer::from_slice_2d(&[&[5.0_f64], &[6.0]]).unwrap();
+    let out = Buffer::concatenate(&[&a, &b], 1).unwrap();
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(out.get::<f64>(&[0, 2]).unwrap(), 5.0);
+    assert_eq!(out.get::<f64>(&[1, 2]).unwrap(), 6.0);
+}
+
+#[test]
+fn concatenate_dtype_promotion() {
+    let a = Buffer::from_slice(&[1_i32, 2, 3]).unwrap();
+    let b = Buffer::from_slice(&[4.0_f64, 5.0, 6.0]).unwrap();
+    let out = Buffer::concatenate(&[&a, &b], 0).unwrap();
+    assert_eq!(out.dtype(), DType::F64);
+    assert_eq!(out.shape(), &[6]);
+}
+
+#[test]
+fn concatenate_three_arrays() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0]).unwrap();
+    let b = Buffer::from_slice(&[3.0_f64]).unwrap();
+    let c = Buffer::from_slice(&[4.0_f64, 5.0, 6.0]).unwrap();
+    let out = Buffer::concatenate(&[&a, &b, &c], 0).unwrap();
+    assert_eq!(out.shape(), &[6]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+}
+
+#[test]
+fn concatenate_empty_input_returns_error() {
+    let err = Buffer::concatenate(&[], 0).unwrap_err();
+    assert!(matches!(err, MohuError::EmptyStackSequence));
+}
+
+#[test]
+fn concatenate_axis_out_of_range_returns_error() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0]).unwrap();
+    let err = Buffer::concatenate(&[&a], 1).unwrap_err();
+    assert!(matches!(err, MohuError::AxisOutOfRange { .. }));
+}
+
+#[test]
+fn concatenate_shape_mismatch_returns_error() {
+    let a = Buffer::from_slice_2d(&[&[1.0_f64, 2.0]]).unwrap();
+    let b = Buffer::from_slice_2d(&[&[3.0_f64, 4.0, 5.0]]).unwrap();
+    let err = Buffer::concatenate(&[&a, &b], 0).unwrap_err();
+    assert!(matches!(err, MohuError::ConcatShapeMismatch { .. }));
+}
+
+// ── stack ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn stack_1d_arrays_axis0() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0, 3.0]).unwrap();
+    let b = Buffer::from_slice(&[4.0_f64, 5.0, 6.0]).unwrap();
+    let out = Buffer::stack(&[&a, &b], 0).unwrap();
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(out.get::<f64>(&[0, 0]).unwrap(), 1.0);
+    assert_eq!(out.get::<f64>(&[1, 2]).unwrap(), 6.0);
+}
+
+#[test]
+fn stack_1d_arrays_axis1() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0, 3.0]).unwrap();
+    let b = Buffer::from_slice(&[4.0_f64, 5.0, 6.0]).unwrap();
+    let out = Buffer::stack(&[&a, &b], 1).unwrap();
+    assert_eq!(out.shape(), &[3, 2]);
+    assert_eq!(out.get::<f64>(&[0, 0]).unwrap(), 1.0);
+    assert_eq!(out.get::<f64>(&[0, 1]).unwrap(), 4.0);
+    assert_eq!(out.get::<f64>(&[2, 1]).unwrap(), 6.0);
+}
+
+#[test]
+fn stack_empty_input_returns_error() {
+    let err = Buffer::stack(&[], 0).unwrap_err();
+    assert!(matches!(err, MohuError::EmptyStackSequence));
+}
+
+#[test]
+fn stack_shape_mismatch_returns_error() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0]).unwrap();
+    let b = Buffer::from_slice(&[3.0_f64, 4.0, 5.0]).unwrap();
+    let err = Buffer::stack(&[&a, &b], 0).unwrap_err();
+    assert!(matches!(err, MohuError::ConcatShapeMismatch { .. }));
 }

--- a/crates/mohu-dtype/src/dtype.rs
+++ b/crates/mohu-dtype/src/dtype.rs
@@ -460,6 +460,7 @@ impl DType {
     /// Accepts canonical names, single-char codes, shorthand with byte counts,
     /// and common aliases. Case-insensitive except for uppercase char codes
     /// (B, H, I, L, F, D).
+    #[allow(clippy::should_implement_trait)] // intentional: not a FromStr impl; returns MohuResult
     pub fn from_str(s: &str) -> MohuResult<Self> {
         let lower = s.trim().to_ascii_lowercase();
         match lower.as_str() {

--- a/crates/mohu-dtype/src/finfo.rs
+++ b/crates/mohu-dtype/src/finfo.rs
@@ -98,7 +98,7 @@ impl FloatInfo {
         let tiny            = half::f16::MIN_POSITIVE.to_f64();
         // Smallest subnormal: 2^{-24}
         let smallest_sub    = 5.960_464_477_539_063e-8_f64;
-        let precision       = (10_u32 as f64 * f64::log10(2.0)).floor() as u32; // 3
+        let precision       = (10.0_f64 * f64::log10(2.0)).floor() as u32; // 3
         Self {
             dtype:             DType::F16,
             bits:              16,
@@ -127,7 +127,7 @@ impl FloatInfo {
         let max             = half::bf16::MAX.to_f64();
         let tiny            = half::bf16::MIN_POSITIVE.to_f64();
         let smallest_sub    = 9.183_549_615_799_121e-41_f64;
-        let precision       = (7_u32 as f64 * f64::log10(2.0)).floor() as u32; // 2
+        let precision       = (7.0_f64 * f64::log10(2.0)).floor() as u32; // 2
         Self {
             dtype:             DType::BF16,
             bits:              16,
@@ -155,7 +155,7 @@ impl FloatInfo {
         let max             = f32::MAX as f64;
         let tiny            = f32::MIN_POSITIVE as f64;
         let smallest_sub    = 1.401_298_464_324_817e-45_f64;
-        let precision       = (23_u32 as f64 * f64::log10(2.0)).floor() as u32; // 6
+        let precision       = (23.0_f64 * f64::log10(2.0)).floor() as u32; // 6
         Self {
             dtype:             DType::F32,
             bits:              32,
@@ -183,7 +183,7 @@ impl FloatInfo {
         let max             = f64::MAX;
         let tiny            = f64::MIN_POSITIVE;
         let smallest_sub    = 5.0e-324_f64;
-        let precision       = (52_u32 as f64 * f64::log10(2.0)).floor() as u32; // 15
+        let precision       = (52.0_f64 * f64::log10(2.0)).floor() as u32; // 15
         Self {
             dtype:             DType::F64,
             bits:              64,

--- a/crates/mohu-dtype/src/iinfo.rs
+++ b/crates/mohu-dtype/src/iinfo.rs
@@ -112,11 +112,7 @@ impl IntInfo {
 
     /// Returns `true` if the unsigned value `v` fits in this dtype.
     pub fn can_hold_u128(self, v: u128) -> bool {
-        if self.is_signed {
-            v <= self.max
-        } else {
-            v <= self.max
-        }
+        v <= self.max
     }
 
     /// Returns the minimum scalar type (smallest integer dtype) that can

--- a/crates/mohu-dtype/src/macros.rs
+++ b/crates/mohu-dtype/src/macros.rs
@@ -1,24 +1,24 @@
-/// Compile-time and runtime dispatch macros for scalar types.
-///
-/// These macros are the foundation of how mohu achieves zero-overhead
-/// generic dispatch over runtime `DType` values.  Every hot-path kernel
-/// in `mohu-buffer`, `mohu-array`, and `mohu-ops` uses `dispatch_dtype!`
-/// to monomorphise a single generic function over the correct scalar type
-/// without a vtable or allocation.
-///
-/// # Macro reference
-///
-/// | Macro | Purpose |
-/// |-------|---------|
-/// | [`dtype_of!`] | `DType` constant for a Rust type literal |
-/// | [`dispatch_dtype!`] | runtime DType → monomorphised call |
-/// | [`dispatch_numeric!`] | same, excluding `Bool` |
-/// | [`dispatch_integer!`] | integers only |
-/// | [`dispatch_float!`] | floats only (F16/BF16/F32/F64) |
-/// | [`dispatch_real!`] | integers + real floats (no complex, no bool) |
-/// | [`dispatch_signed!`] | signed integers + floats |
-/// | [`for_each_dtype!`] | invoke a macro for every dtype (codegen helper) |
-/// | [`assert_dtype!`] | assert a DType at runtime or return an error |
+//! Compile-time and runtime dispatch macros for scalar types.
+//!
+//! These macros are the foundation of how mohu achieves zero-overhead
+//! generic dispatch over runtime `DType` values.  Every hot-path kernel
+//! in `mohu-buffer`, `mohu-array`, and `mohu-ops` uses `dispatch_dtype!`
+//! to monomorphise a single generic function over the correct scalar type
+//! without a vtable or allocation.
+//!
+//! # Macro reference
+//!
+//! | Macro | Purpose |
+//! |-------|---------|
+//! | [`dtype_of!`] | `DType` constant for a Rust type literal |
+//! | [`dispatch_dtype!`] | runtime DType → monomorphised call |
+//! | [`dispatch_numeric!`] | same, excluding `Bool` |
+//! | [`dispatch_integer!`] | integers only |
+//! | [`dispatch_float!`] | floats only (F16/BF16/F32/F64) |
+//! | [`dispatch_real!`] | integers + real floats (no complex, no bool) |
+//! | [`dispatch_signed!`] | signed integers + floats |
+//! | [`for_each_dtype!`] | invoke a macro for every dtype (codegen helper) |
+//! | [`assert_dtype!`] | assert a DType at runtime or return an error |
 
 // ─── dtype_of! ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #144.

Adds two new methods to `Buffer`:

**`Buffer::concatenate(arrays: &[&Buffer], axis: usize) -> MohuResult<Buffer>`**
- Joins a sequence of buffers along an existing axis
- Dtype promotion via `common_type` (NumPy-compatible rules)
- Block-copy algorithm operating on C-contiguous data (zero extra allocations beyond cast if dtype already matches)
- Errors: `EmptyStackSequence`, `AxisOutOfRange`, `DimensionMismatch`, `ConcatShapeMismatch`

**`Buffer::stack(arrays: &[&Buffer], axis: usize) -> MohuResult<Buffer>`**
- Joins arrays along a **new** axis inserted at `axis` (0..=ndim)
- Delegates to `concatenate` after `reshape` to insert a size-1 axis
- Errors: `EmptyStackSequence`, `AxisOutOfRange`, `ConcatShapeMismatch`

## Changes

- `crates/mohu-buffer/src/buffer.rs`: added `common_type` import; new `concatenate` and `stack` methods before the closing brace of `impl Buffer`
- `crates/mohu-buffer/tests/integration.rs`: 11 integration tests covering axis 0/1 concat, dtype promotion, 3-array concat, empty/OOB/mismatch errors, stack axis 0/1, stack empty/mismatch

## Test plan

- [ ] `cargo test -p mohu-buffer --all-features` passes
- [ ] `cargo clippy -p mohu-buffer --all-targets --all-features -- -D warnings` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added array concatenation with dtype promotion, shape/rank validation, and stacking along a new axis.

* **Tests**
  * Extended integration tests for concatenation and stacking, including dtype promotion and error cases.

* **Bug Fixes**
  * Minor correctness tweaks to float precision calculations and integer range checks.

* **Documentation / Chores**
  * Minor docs formatting and CI workflow adjustment; added a linter suppression for a dtype parsing helper.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->