### PR TITLE
test(buffer): add integration tests for AllocStats memory accounting …

### DIFF
--- a/crates/mohu-buffer/tests/alloc_stats_tests.rs
+++ b/crates/mohu-buffer/tests/alloc_stats_tests.rs
@@ -13,7 +13,7 @@ fn single_allocation_increments_count_and_bytes() {
 
     assert_eq!(alloc_delta, 1);
 
-    assert_ne!(after.live_bytes, before.live_bytes);
+    assert!(after.live_bytes > before.live_bytes);
 }
 
 #[test]
@@ -28,7 +28,7 @@ fn drop_decrements_live_bytes() {
 
     assert!(after.free_count >= before.free_count + 1);
 
-    assert!(after.live_bytes <= before.live_bytes + 200 * std::mem::size_of::<f64>() as i64);
+    assert!(after.live_bytes <= before.live_bytes);
 }
 
 #[test]

--- a/crates/mohu-buffer/tests/alloc_stats_tests.rs
+++ b/crates/mohu-buffer/tests/alloc_stats_tests.rs
@@ -40,7 +40,7 @@ fn clone_increments_alloc_count() {
 
     let after = AllocStats::snapshot();
 
-    assert_eq!(after.alloc_count, before.alloc_count + 1);
+    assert_eq!(after.alloc_count, before.alloc_count + 2);
 }
 
 #[test]

--- a/crates/mohu-buffer/tests/alloc_stats_tests.rs
+++ b/crates/mohu-buffer/tests/alloc_stats_tests.rs
@@ -1,0 +1,57 @@
+use mohu_buffer::{AllocStats, Buffer};
+use mohu_dtype::DType;
+
+#[test]
+fn single_allocation_increments_count_and_bytes() {
+    let before = AllocStats::snapshot();
+
+    let _buf = Buffer::zeros(DType::F64, &[100]).unwrap();
+
+    let after = AllocStats::snapshot();
+
+    let alloc_delta = after.alloc_count - before.alloc_count;
+
+    assert_eq!(alloc_delta, 1);
+
+    assert_ne!(after.live_bytes, before.live_bytes);
+}
+
+#[test]
+fn drop_decrements_live_bytes() {
+    let before = AllocStats::snapshot();
+
+    {
+        let _buf = Buffer::zeros(DType::F64, &[200]).unwrap();
+    }
+
+    let after = AllocStats::snapshot();
+
+    assert!(after.free_count >= before.free_count + 1);
+
+    assert!(after.live_bytes <= before.live_bytes + 200 * std::mem::size_of::<f64>() as i64);
+}
+
+#[test]
+fn clone_increments_alloc_count() {
+    let before = AllocStats::snapshot();
+
+    let buf = Buffer::zeros(DType::F64, &[50]).unwrap();
+    let _clone = buf.clone();
+
+    let after = AllocStats::snapshot();
+
+    assert_eq!(after.alloc_count, before.alloc_count + 1);
+}
+
+#[test]
+fn zero_size_allocation() {
+    let before = AllocStats::snapshot();
+
+    let _buf = Buffer::zeros(DType::F64, &[]).unwrap();
+
+    let after = AllocStats::snapshot();
+
+    assert!(after.alloc_count >= before.alloc_count);
+
+    assert!(after.live_bytes >= before.live_bytes);
+}


### PR DESCRIPTION
Closes #147

## What
Adds a new file `alloc_stats_tests.rs` in `crates/mohu-buffer/tests`.
It introduces integration tests for AllocStats memory accounting.
<!-- Brief summary of what this PR changes -->

## Why
AllocStats tracks allocation counts and byte totals. But there were no integration tests verifying that the counters update correctly when buffers are created, cloned, and dropped.
<!-- Why is this change needed? Link issues if applicable -->

## How
1. A test file named `alloc_stats_tests.rs` was created in `crates/mohu-buffer/tests`.
2. Four tests were added to check:
    - Test: single allocation increments count and bytes correctly
    - Test: drop decrements bytes (or a separate dealloc counter if one exists)
    - Test: clone increments count again (two independent allocations)
    - Test: zero-size allocation (Buffer::zeros(DType::F64, &[])) handled without panic
3. The tests use actual APIs for `AllocStats` source
4. Each test follows the same flow:
    - Take `AllocStats::snapshot()` before the operation
    - Perform a real Buffer operation (zeros, clone, or scoped drop)
    - Take snapshot again
    - Compare fields like `alloc_count`, `free_count`, and `live_bytes` using assertions (`assert_eq!`, `assert!`, etc.)
<!-- Key implementation decisions reviewers should know about -->

## Checklist

- [x] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all` applied
- [ ] `CHANGELOG.md` updated (if user-facing change) _NOT REQUIRED_
- [ ] Benchmarks added or updated (if performance-sensitive path)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying buffer allocation tracking across four scenarios: normal allocation increases allocation count and live memory; scoped drop increments deallocation counts without raising live memory; cloning registers an extra allocation; and zero-sized allocations do not change allocation counts or live memory. These tests improve confidence in allocation/free accounting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->