### PR TITLE
feat(buffer): add unsqueeze and squeeze_axis methods

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -777,6 +777,24 @@ impl Buffer {
         })
     }
 
+    /// Inserts a size-1 dimension at `axis`.
+    ///
+    /// This is the PyTorch-style name for [`expand_dims`](Self::expand_dims).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use mohu_buffer::buffer::Buffer;
+    /// # use mohu_buffer::layout::Order;
+    /// # use mohu_dtype::dtype::DType;
+    /// let buf = Buffer::alloc(DType::F32, &[3, 4], Order::C).unwrap();
+    /// let expanded = buf.unsqueeze(1).unwrap();
+    /// assert_eq!(expanded.shape(), &[3, 1, 4]);
+    /// ```
+    pub fn unsqueeze(&self, axis: usize) -> MohuResult<Self> {
+        self.expand_dims(axis)
+    }
+
     /// Removes all axes of size 1.
     pub fn squeeze(&self) -> Self {
         Self {
@@ -785,6 +803,30 @@ impl Buffer {
             layout: self.layout.squeeze(),
             flags:  self.flags,
         }
+    }
+
+    /// Removes the size-1 axis at `axis`.
+    ///
+    /// Returns an error if `axis` is out of range or not a size-1 axis.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use mohu_buffer::buffer::Buffer;
+    /// # use mohu_buffer::layout::Order;
+    /// # use mohu_dtype::dtype::DType;
+    /// let buf = Buffer::alloc(DType::F32, &[1, 3, 4], Order::C).unwrap();
+    /// let squeezed = buf.squeeze_axis(0).unwrap();
+    /// assert_eq!(squeezed.shape(), &[3, 4]);
+    /// ```
+    pub fn squeeze_axis(&self, axis: usize) -> MohuResult<Self> {
+        let layout = self.layout.squeeze_axis(axis)?;
+        Ok(Self {
+            raw:    Arc::clone(&self.raw),
+            dtype:  self.dtype,
+            layout,
+            flags:  self.flags,
+        })
     }
 
     // ─── Type cast ────────────────────────────────────────────────────────────

--- a/crates/mohu-buffer/src/layout.rs
+++ b/crates/mohu-buffer/src/layout.rs
@@ -328,6 +328,22 @@ impl Layout {
         })
     }
 
+    /// Inserts a size-1 dimension at `axis`. `axis` must be `<= self.ndim()`.
+    ///
+    /// This is the PyTorch-style name for [`expand_dims`](Self::expand_dims).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use mohu_buffer::layout::Layout;
+    /// let layout = Layout::new_c(&[3, 4], 4).unwrap();
+    /// let expanded = layout.unsqueeze(1).unwrap();
+    /// assert_eq!(expanded.shape(), &[3, 1, 4]);
+    /// ```
+    pub fn unsqueeze(&self, axis: usize) -> MohuResult<Self> {
+        self.expand_dims(axis)
+    }
+
     /// Removes all axes of size 1.
     ///
     /// Equivalent to `np.squeeze(a)`.

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -279,3 +279,46 @@ fn nd_index_iter_c_order() {
     assert_eq!(indices[3].as_slice(), &[1, 0]);
     assert_eq!(indices[5].as_slice(), &[1, 2]);
 }
+
+// ── Squeeze / Unsqueeze ─────────────────────────────────────────────────────
+
+#[test]
+fn squeeze_axis_removes_size_one_dim() {
+    let buf = Buffer::alloc(DType::F32, &[1, 3, 4], Order::C).unwrap();
+    let squeezed = buf.squeeze_axis(0).unwrap();
+    assert_eq!(squeezed.shape(), &[3, 4]);
+}
+
+#[test]
+fn squeeze_axis_non_unit_returns_error() {
+    let buf = Buffer::alloc(DType::F32, &[2, 3, 4], Order::C).unwrap();
+    assert!(buf.squeeze_axis(0).is_err());
+}
+
+#[test]
+fn unsqueeze_inserts_size_one_dim() {
+    let buf = Buffer::alloc(DType::F32, &[3, 4], Order::C).unwrap();
+    let expanded = buf.unsqueeze(1).unwrap();
+    assert_eq!(expanded.shape(), &[3, 1, 4]);
+}
+
+#[test]
+fn unsqueeze_then_squeeze_roundtrips() {
+    let buf = Buffer::alloc(DType::F32, &[3, 4], Order::C).unwrap();
+    let expanded = buf.unsqueeze(0).unwrap();
+    assert_eq!(expanded.shape(), &[1, 3, 4]);
+    let back = expanded.squeeze_axis(0).unwrap();
+    assert_eq!(back.shape(), &[3, 4]);
+}
+
+#[test]
+fn double_unsqueeze_then_squeeze_roundtrips() {
+    let buf = Buffer::alloc(DType::F32, &[3, 4], Order::C).unwrap();
+    let e1 = buf.unsqueeze(0).unwrap();
+    let e2 = e1.unsqueeze(2).unwrap();
+    assert_eq!(e2.shape(), &[1, 3, 1, 4]);
+    let s1 = e2.squeeze_axis(2).unwrap();
+    assert_eq!(s1.shape(), &[1, 3, 4]);
+    let s2 = s1.squeeze_axis(0).unwrap();
+    assert_eq!(s2.shape(), &[3, 4]);
+}

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -303,6 +303,18 @@ fn unsqueeze_inserts_size_one_dim() {
 }
 
 #[test]
+fn squeeze_axis_out_of_range_returns_error() {
+    let buf = Buffer::alloc(DType::F32, &[1, 3, 4], Order::C).unwrap();
+    assert!(buf.squeeze_axis(3).is_err());
+}
+
+#[test]
+fn unsqueeze_out_of_range_returns_error() {
+    let buf = Buffer::alloc(DType::F32, &[3, 4], Order::C).unwrap();
+    assert!(buf.unsqueeze(3).is_err());
+}
+
+#[test]
 fn unsqueeze_then_squeeze_roundtrips() {
     let buf = Buffer::alloc(DType::F32, &[3, 4], Order::C).unwrap();
     let expanded = buf.unsqueeze(0).unwrap();


### PR DESCRIPTION
## Summary

Adds `Layout::unsqueeze(axis)` and `Buffer::unsqueeze(axis)` as PyTorch-style aliases for `expand_dims`, and adds `Buffer::squeeze_axis(axis)` to expose the per-axis squeeze on Buffer.

Closes #117

## Changes

- `crates/mohu-buffer/src/layout.rs` — add `Layout::unsqueeze(axis)` with doc comment and example
- `crates/mohu-buffer/src/buffer.rs` — add `Buffer::unsqueeze(axis)` and `Buffer::squeeze_axis(axis)` with doc comments and examples
- `crates/mohu-buffer/tests/integration.rs` — 5 new integration tests

## Acceptance criteria from #117

- [x] Both methods on `Layout` and `Buffer` with doc comments
- [x] Error returned (not panic) for invalid axis or non-unit squeeze
- [x] Roundtrip test passes
- [x] `cargo test -p mohu-buffer` passes (32 tests + 4 doc-tests)

## Testing

```
cargo test -p mohu-buffer --all-features
# 32 passed; 0 failed; 0 ignored
# Doc-tests: 4 passed; 4 ignored (unrelated)
```

Note: pre-existing clippy warnings in `mohu-dtype` and the existing integration test (`3.14` approx PI lint) are not introduced by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unsqueeze() to insert singleton dimensions and squeeze_axis() to remove them, matching PyTorch-style shape manipulation.
* **Tests**
  * Added integration tests verifying insertion/removal behavior, error cases for invalid axes, and round-trip shape restoration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->