### PR TITLE
docs(mohu-array): add README.md for NdArray<T> crate

### DIFF
--- a/crates/mohu-array/README.md
+++ b/crates/mohu-array/README.md
@@ -1,0 +1,104 @@
+# mohu-array
+
+`mohu-array` provides `NdArray<T>`, the core typed N-dimensional array type in the [mohu](../../README.md) workspace. It composes `mohu-buffer` (memory + layout), `mohu-dtype` (scalar type system), and shape/slice/view abstractions into a single ergonomic Rust generic interface for numerical computing.
+
+---
+
+## Relationship to `mohu-buffer`
+
+```
+NdArray<T>  =  mohu-buffer::Buffer  +  type parameter T : Scalar (from mohu-dtype)
+```
+
+`mohu-buffer` owns the raw bytes, shape, and strides. `mohu-array` adds the generic type parameter `T` (bounded by `num-traits` scalar traits and `mohu-dtype`'s type system) so that element-level operations are type-safe without runtime casting. Parallel operations are powered by `rayon`.
+
+Internal modules:
+
+| Module | Role |
+|---|---|
+| `array` | `NdArray<T>` struct definition |
+| `shape` | Shape representation and validation |
+| `slice` | Slice argument types for sub-array selection |
+| `view` | Zero-copy array views |
+| `iter` | Iterators over elements and axes |
+
+---
+
+## Planned API Surface
+
+> **Status:** implementation is in progress — all source files are currently stubs.
+> The API below reflects the planned design; signatures may change before stabilisation.
+> See the [issue tracker](https://github.com/mohu-org/mohu/issues?q=label%3A%22crate%3A+mohu-array%22) for progress.
+
+### Construction
+
+```rust
+// All-zeros array of shape [3, 4]
+let a = NdArray::<f64>::zeros(&[3, 4]);
+
+// All-ones array
+let b = NdArray::<f32>::ones(&[2, 2, 2]);
+
+// From an existing flat slice (row-major by default)
+let c = NdArray::<i32>::from_slice(&[1, 2, 3, 4, 5, 6], &[2, 3]);
+```
+
+### Indexing
+
+```rust
+// Element access
+let val: f64 = a[[1, 2]];
+
+// Mutable element access
+a[[0, 0]] = 3.14;
+
+// Slicing — returns a zero-copy view
+let row = a.slice(s![0, ..]);
+```
+
+### Arithmetic
+
+```rust
+// Element-wise operators (parallel via rayon internally)
+let sum  = &a + &b;
+let diff = &a - &b;
+let prod = &a * &b;
+
+// Scalar broadcast
+let scaled = &a * 2.0;
+```
+
+### Shape Manipulation
+
+```rust
+// Reshape (total element count must match)
+let flat = a.reshape(&[12]);
+
+// Transpose — reverses axis order, returns a view
+let t = a.transpose();
+```
+
+---
+
+## Status
+
+`mohu-array` is **under active development** and is not yet published to [crates.io](https://crates.io). All `.rs` files are currently module stubs. Implementation is being tracked in the [mohu issue tracker](https://github.com/mohu-org/mohu/issues?q=label%3A%22crate%3A+mohu-array%22).
+
+Do not depend on this crate in production — public API stability is not guaranteed before the first versioned release.
+
+---
+
+## Related Crates
+
+| Crate | Role |
+|---|---|
+| [`mohu-buffer`](../mohu-buffer/README.md) | Untyped memory layer — raw bytes, shape, strides |
+| `mohu-dtype` | `Scalar` trait and `DType` enum used by `NdArray<T>` |
+| `mohu-error` | Structured error types used across the workspace |
+| `mohu-core` | Re-export facade — import this instead of individual crates |
+
+---
+
+## Contributing
+
+Please read the workspace-level [CONTRIBUTING.md](../../CONTRIBUTING.md) before opening a pull request. All contributions — bug reports, API design feedback, and code — are welcome.

--- a/crates/mohu-array/README.md
+++ b/crates/mohu-array/README.md
@@ -6,7 +6,7 @@
 
 ## Relationship to `mohu-buffer`
 
-```
+```text
 NdArray<T>  =  mohu-buffer::Buffer  +  type parameter T : Scalar (from mohu-dtype)
 ```
 


### PR DESCRIPTION
## What
Adds `crates/mohu-array/README.md` as requested in #124.

## Why
The crate had no documentation. Contributors and users had no way to understand what `NdArray<T>` is, how it relates to `mohu-buffer`, or what API is planned.

## How
Created a README covering:
- One-paragraph description of `NdArray<T>`
- Relationship to `mohu-buffer` (NdArray = Buffer + type parameter T implementing Scalar)
- Planned API surface (zeros, ones, from_slice, indexing, arithmetic, reshape, transpose)
- Module table (array, shape, slice, view, iter)
- Status note (implementation in progress)
- Link to workspace CONTRIBUTING.md
- Link to mohu-buffer README

## Checklist
- [ ] `cargo test --workspace` passes — N/A (docs only)
- [ ] `cargo clippy --workspace -- -D warnings` passes — N/A (docs only)
- [ ] `cargo fmt --all` applied — N/A (docs only)
- [ ] `CHANGELOG.md` updated — N/A (not a user-facing code change)
- [ ] Benchmarks added or updated — N/A (docs only)

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive README for the mohu-array crate describing the core typed N-dimensional array interface, its relationship to related components, planned API areas (construction, indexing/slicing, arithmetic, shape manipulation) with usage examples, current active development status, guidance for contributors, and pointers to related crates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->