### PR TITLE
feat(mohu-dtype): implement Default for DType returning F64 

### DIFF
--- a/crates/mohu-dtype/src/dtype.rs
+++ b/crates/mohu-dtype/src/dtype.rs
@@ -553,7 +553,21 @@ impl<'de> serde::Deserialize<'de> for DType {
 }
 
 // ─── compile-time invariant checks ───────────────────────────────────────────
+// ─── Default ─────────────────────────────────────────────────────────────────
 
+impl Default for DType {
+    /// Returns [`DType::F64`] as the default dtype, matching NumPy's
+    /// default floating-point type (`float64`).
+    ///
+    /// # Example
+    /// ```
+    /// use mohu_dtype::DType;
+    /// assert_eq!(DType::default(), DType::F64);
+    /// ```
+    fn default() -> Self {
+        Self::F64
+    }
+}
 const _: () = {
     assert!(ALL_DTYPES.len() == DTYPE_COUNT);
     assert!(DType::Bool as u8 == 0);

--- a/crates/mohu-dtype/tests/dtype_tests.rs
+++ b/crates/mohu-dtype/tests/dtype_tests.rs
@@ -1,0 +1,15 @@
+use mohu_dtype::DType;
+
+#[test]
+fn default_dtype_is_f64() {
+    assert_eq!(DType::default(), DType::F64);
+}
+
+#[test]
+fn struct_deriving_default_uses_f64() {
+    #[derive(Default)]
+    struct Config {
+        dtype: DType,
+    }
+    assert_eq!(Config::default().dtype, DType::F64);
+}


### PR DESCRIPTION
## What
Implements `Default` for `DType` returning `DType::F64`, matching
NumPy's default floating-point type (`float64`).

## Why
`DType` had no `Default` impl, making it impossible to use
`DType::default()` or `#[derive(Default)]` on structs with a
`DType` field.

## How
- Added `impl Default for DType` in `dtype.rs` with doc comment and example
- Added two tests in `crates/mohu-dtype/tests/dtype_tests.rs`:
  - `default_dtype_is_f64` — checks `DType::default() == DType::F64`
  - `struct_deriving_default_uses_f64` — checks `#[derive(Default)]` works

## Checklist
- [x] Branch rebased on upstream/main
- [x] Commit signed off
- [x] Doc comment with example added
- [ ] cargo fmt — N/A (minimal change)
- [ ] CHANGELOG.md — N/A (no user-facing API break)

Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `DType` now implements the `Default` trait, defaulting to `F64` type, aligning with NumPy's standard convention to improve usability when default data types are required.

* **Tests**
  * Added comprehensive test coverage to verify the default behavior of `DType` and confirm that struct fields derive the correct default value.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->