### PR TITLE
feat(core): implement comparison ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,9 @@ dependencies = [
 name = "mohu-ops"
 version = "0.1.0"
 dependencies = [
+ "half",
  "mohu-core",
+ "num-complex",
  "num-traits",
  "rayon",
  "thiserror",

--- a/crates/mohu-ops/Cargo.toml
+++ b/crates/mohu-ops/Cargo.toml
@@ -12,6 +12,10 @@ categories.workspace  = true
 
 [dependencies]
 mohu-core.workspace   = true
+half.workspace        = true
+num-complex.workspace = true
 num-traits.workspace  = true
 rayon.workspace       = true
 thiserror.workspace   = true
+
+[dev-dependencies]

--- a/crates/mohu-ops/src/broadcast.rs
+++ b/crates/mohu-ops/src/broadcast.rs
@@ -1,0 +1,58 @@
+use mohu_core::mohu_buffer::Buffer;
+use mohu_core::mohu_error::{MohuError, MohuResult};
+
+/// Computes the broadcasted output shape for two input shapes.
+pub(crate) fn broadcast_shape(lhs: &[usize], rhs: &[usize]) -> MohuResult<Vec<usize>> {
+    let out_ndim = lhs.len().max(rhs.len());
+    let mut out = Vec::with_capacity(out_ndim);
+
+    for i in 0..out_ndim {
+        let l = if i < lhs.len() { lhs[lhs.len() - 1 - i] } else { 1 };
+        let r = if i < rhs.len() { rhs[rhs.len() - 1 - i] } else { 1 };
+        if l == r || l == 1 || r == 1 {
+            out.push(l.max(r));
+        } else {
+            return Err(MohuError::ShapeMismatch {
+                expected: lhs.to_vec(),
+                got:      rhs.to_vec(),
+            });
+        }
+    }
+
+    out.reverse();
+    Ok(out)
+}
+
+pub(crate) fn broadcast_binary_inputs(
+    lhs: &Buffer,
+    rhs: &Buffer,
+) -> MohuResult<(Buffer, Buffer, Vec<usize>)> {
+    let out_shape = broadcast_shape(lhs.shape(), rhs.shape())?;
+
+    let lhs_same_shape = lhs.shape() == out_shape.as_slice();
+    let rhs_same_shape = rhs.shape() == out_shape.as_slice();
+
+    let lhs_view = if lhs_same_shape {
+        lhs.share()
+    } else {
+        lhs.broadcast_to(&out_shape)?
+    };
+    let rhs_view = if rhs_same_shape {
+        rhs.share()
+    } else {
+        rhs.broadcast_to(&out_shape)?
+    };
+
+    let lhs_contig = if lhs_same_shape && lhs_view.is_c_contiguous() {
+        lhs_view
+    } else {
+        lhs_view.to_contiguous()?
+    };
+    let rhs_contig = if rhs_same_shape && rhs_view.is_c_contiguous() {
+        rhs_view
+    } else {
+        rhs_view.to_contiguous()?
+    };
+
+    Ok((lhs_contig, rhs_contig, out_shape))
+}

--- a/crates/mohu-ops/src/cmp.rs
+++ b/crates/mohu-ops/src/cmp.rs
@@ -1,0 +1,326 @@
+use mohu_core::mohu_buffer::ops::parallel_zip;
+use mohu_core::mohu_buffer::Buffer;
+use mohu_core::mohu_dtype::{dispatch_dtype, dispatch_real, DType};
+use mohu_core::mohu_error::{MohuError, MohuResult};
+
+use crate::broadcast::broadcast_binary_inputs;
+
+#[derive(Clone, Copy)]
+enum CmpKind {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+
+impl CmpKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Eq => "eq",
+            Self::Ne => "ne",
+            Self::Lt => "lt",
+            Self::Le => "le",
+            Self::Gt => "gt",
+            Self::Ge => "ge",
+        }
+    }
+
+    fn is_ordered(self) -> bool {
+        matches!(self, Self::Lt | Self::Le | Self::Gt | Self::Ge)
+    }
+}
+
+fn compare_binary(lhs: &Buffer, rhs: &Buffer, kind: CmpKind) -> MohuResult<Buffer> {
+    if lhs.dtype() != rhs.dtype() {
+        return Err(MohuError::DTypeMismatch {
+            expected: lhs.dtype().to_string(),
+            got:      rhs.dtype().to_string(),
+        });
+    }
+    if kind.is_ordered() && lhs.dtype().is_complex() {
+        return Err(MohuError::domain(
+            kind.name(),
+            "ordered comparisons are undefined for complex dtypes",
+        ));
+    }
+
+    let (lhs_buf, rhs_buf, out_shape) = broadcast_binary_inputs(lhs, rhs)?;
+    let mut out = Buffer::zeros(DType::Bool, &out_shape)?;
+
+    match kind {
+        CmpKind::Eq => {
+            macro_rules! do_cmp {
+                ($T:ty) => {
+                    parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a == b)
+                };
+            }
+            dispatch_dtype!(lhs.dtype(), do_cmp)?;
+        }
+        CmpKind::Ne => {
+            macro_rules! do_cmp {
+                ($T:ty) => {
+                    parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a != b)
+                };
+            }
+            dispatch_dtype!(lhs.dtype(), do_cmp)?;
+        }
+        CmpKind::Lt => {
+            if lhs.dtype() == DType::Bool {
+                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a < b)?;
+            } else {
+                macro_rules! do_cmp {
+                    ($T:ty) => {
+                        parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a < b)
+                    };
+                }
+                dispatch_real!(lhs.dtype(), do_cmp)??;
+            }
+        }
+        CmpKind::Le => {
+            if lhs.dtype() == DType::Bool {
+                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a <= b)?;
+            } else {
+                macro_rules! do_cmp {
+                    ($T:ty) => {
+                        parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a <= b)
+                    };
+                }
+                dispatch_real!(lhs.dtype(), do_cmp)??;
+            }
+        }
+        CmpKind::Gt => {
+            if lhs.dtype() == DType::Bool {
+                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a > b)?;
+            } else {
+                macro_rules! do_cmp {
+                    ($T:ty) => {
+                        parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a > b)
+                    };
+                }
+                dispatch_real!(lhs.dtype(), do_cmp)??;
+            }
+        }
+        CmpKind::Ge => {
+            if lhs.dtype() == DType::Bool {
+                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a >= b)?;
+            } else {
+                macro_rules! do_cmp {
+                    ($T:ty) => {
+                        parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a >= b)
+                    };
+                }
+                dispatch_real!(lhs.dtype(), do_cmp)??;
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Element-wise equality comparison.
+///
+/// The output dtype is always `Bool`.
+///
+/// # Example
+///
+/// ```rust
+/// # use mohu_core::mohu_buffer::Buffer;
+/// # use mohu_core::mohu_error::MohuResult;
+/// # use mohu_ops::cmp::eq;
+/// # fn main() -> MohuResult<()> {
+/// let a = Buffer::from_slice(&[1_i32, 2, 3])?;
+/// let b = Buffer::from_slice(&[1_i32, 0, 3])?;
+/// let out = eq(&a, &b)?;
+/// assert_eq!(out.to_vec::<bool>()?, vec![true, false, true]);
+/// # Ok(())
+/// # }
+/// ```
+pub fn eq(lhs: &Buffer, rhs: &Buffer) -> MohuResult<Buffer> {
+    compare_binary(lhs, rhs, CmpKind::Eq)
+}
+
+/// Element-wise inequality comparison.
+///
+/// The output dtype is always `Bool`.
+///
+/// # Example
+///
+/// ```rust
+/// # use mohu_core::mohu_buffer::Buffer;
+/// # use mohu_core::mohu_error::MohuResult;
+/// # use mohu_ops::cmp::ne;
+/// # fn main() -> MohuResult<()> {
+/// let a = Buffer::from_slice(&[1_i32, 2, 3])?;
+/// let b = Buffer::from_slice(&[1_i32, 0, 3])?;
+/// let out = ne(&a, &b)?;
+/// assert_eq!(out.to_vec::<bool>()?, vec![false, true, false]);
+/// # Ok(())
+/// # }
+/// ```
+pub fn ne(lhs: &Buffer, rhs: &Buffer) -> MohuResult<Buffer> {
+    compare_binary(lhs, rhs, CmpKind::Ne)
+}
+
+/// Element-wise less-than comparison.
+///
+/// The output dtype is always `Bool`.
+///
+/// # Example
+///
+/// ```rust
+/// # use mohu_core::mohu_buffer::Buffer;
+/// # use mohu_core::mohu_error::MohuResult;
+/// # use mohu_ops::cmp::lt;
+/// # fn main() -> MohuResult<()> {
+/// let a = Buffer::from_slice(&[1_i32, 2, 3])?;
+/// let b = Buffer::from_slice(&[2_i32, 2, 1])?;
+/// let out = lt(&a, &b)?;
+/// assert_eq!(out.to_vec::<bool>()?, vec![true, false, false]);
+/// # Ok(())
+/// # }
+/// ```
+pub fn lt(lhs: &Buffer, rhs: &Buffer) -> MohuResult<Buffer> {
+    compare_binary(lhs, rhs, CmpKind::Lt)
+}
+
+/// Element-wise less-than-or-equal comparison.
+///
+/// The output dtype is always `Bool`.
+///
+/// # Example
+///
+/// ```rust
+/// # use mohu_core::mohu_buffer::Buffer;
+/// # use mohu_core::mohu_error::MohuResult;
+/// # use mohu_ops::cmp::le;
+/// # fn main() -> MohuResult<()> {
+/// let a = Buffer::from_slice(&[1_i32, 2, 3])?;
+/// let b = Buffer::from_slice(&[1_i32, 1, 4])?;
+/// let out = le(&a, &b)?;
+/// assert_eq!(out.to_vec::<bool>()?, vec![true, false, true]);
+/// # Ok(())
+/// # }
+/// ```
+pub fn le(lhs: &Buffer, rhs: &Buffer) -> MohuResult<Buffer> {
+    compare_binary(lhs, rhs, CmpKind::Le)
+}
+
+/// Element-wise greater-than comparison.
+///
+/// The output dtype is always `Bool`.
+///
+/// # Example
+///
+/// ```rust
+/// # use mohu_core::mohu_buffer::Buffer;
+/// # use mohu_core::mohu_error::MohuResult;
+/// # use mohu_ops::cmp::gt;
+/// # fn main() -> MohuResult<()> {
+/// let a = Buffer::from_slice(&[1_i32, 2, 3])?;
+/// let b = Buffer::from_slice(&[0_i32, 2, 4])?;
+/// let out = gt(&a, &b)?;
+/// assert_eq!(out.to_vec::<bool>()?, vec![true, false, false]);
+/// # Ok(())
+/// # }
+/// ```
+pub fn gt(lhs: &Buffer, rhs: &Buffer) -> MohuResult<Buffer> {
+    compare_binary(lhs, rhs, CmpKind::Gt)
+}
+
+/// Element-wise greater-than-or-equal comparison.
+///
+/// The output dtype is always `Bool`.
+///
+/// # Example
+///
+/// ```rust
+/// # use mohu_core::mohu_buffer::Buffer;
+/// # use mohu_core::mohu_error::MohuResult;
+/// # use mohu_ops::cmp::ge;
+/// # fn main() -> MohuResult<()> {
+/// let a = Buffer::from_slice(&[1_i32, 2, 3])?;
+/// let b = Buffer::from_slice(&[1_i32, 3, 3])?;
+/// let out = ge(&a, &b)?;
+/// assert_eq!(out.to_vec::<bool>()?, vec![true, false, true]);
+/// # Ok(())
+/// # }
+/// ```
+pub fn ge(lhs: &Buffer, rhs: &Buffer) -> MohuResult<Buffer> {
+    compare_binary(lhs, rhs, CmpKind::Ge)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mohu_core::mohu_error::MohuError;
+    use num_complex::Complex;
+
+    #[test]
+    fn eq_broadcasts_and_returns_bool() {
+        let lhs = Buffer::from_slice(&[1_i32, 2, 3]).unwrap().reshape(&[1, 3]).unwrap();
+        let rhs = Buffer::from_slice(&[1_i32, 0, 3, 1, 2, 4]).unwrap()
+            .reshape(&[2, 3]).unwrap();
+
+        let out = eq(&lhs, &rhs).unwrap();
+        assert_eq!(out.dtype(), DType::Bool);
+        assert_eq!(out.shape(), &[2, 3]);
+        assert_eq!(
+            out.to_vec::<bool>().unwrap(),
+            vec![true, false, true, true, true, false]
+        );
+    }
+
+    #[test]
+    fn nan_semantics_follow_ieee_754() {
+        let lhs = Buffer::from_slice(&[f32::NAN, 1.0_f32]).unwrap();
+        let rhs = Buffer::from_slice(&[f32::NAN, 2.0_f32]).unwrap();
+
+        let out_eq = eq(&lhs, &rhs).unwrap().to_vec::<bool>().unwrap();
+        let out_ne = ne(&lhs, &rhs).unwrap().to_vec::<bool>().unwrap();
+        let out_lt = lt(&lhs, &rhs).unwrap().to_vec::<bool>().unwrap();
+        let out_le = le(&lhs, &rhs).unwrap().to_vec::<bool>().unwrap();
+        let out_gt = gt(&lhs, &rhs).unwrap().to_vec::<bool>().unwrap();
+        let out_ge = ge(&lhs, &rhs).unwrap().to_vec::<bool>().unwrap();
+
+        assert_eq!(out_eq[0], false);
+        assert_eq!(out_ne[0], true);
+        assert_eq!(out_lt[0], false);
+        assert_eq!(out_le[0], false);
+        assert_eq!(out_gt[0], false);
+        assert_eq!(out_ge[0], false);
+
+        assert_eq!(out_lt[1], true);
+        assert_eq!(out_le[1], true);
+        assert_eq!(out_gt[1], false);
+        assert_eq!(out_ge[1], false);
+    }
+
+    #[test]
+    fn ordered_comparison_on_complex_is_domain_error() {
+        let lhs = Buffer::from_slice(&[Complex::new(1.0_f32, 0.0)]).unwrap();
+        let rhs = Buffer::from_slice(&[Complex::new(2.0_f32, 0.0)]).unwrap();
+
+        let err = lt(&lhs, &rhs).unwrap_err();
+        assert!(matches!(err, MohuError::DomainError { .. }));
+    }
+
+    #[test]
+    fn dtype_mismatch_is_error() {
+        let lhs = Buffer::from_slice(&[1_i32, 2, 3]).unwrap();
+        let rhs = Buffer::from_slice(&[1_f32, 2.0, 3.0]).unwrap();
+
+        let err = eq(&lhs, &rhs).unwrap_err();
+        assert!(matches!(err, MohuError::DTypeMismatch { .. }));
+    }
+
+    #[test]
+    fn broadcast_mismatch_is_shape_error() {
+        let lhs = Buffer::from_slice(&[1_i32, 2, 3, 4]).unwrap().reshape(&[2, 2]).unwrap();
+        let rhs = Buffer::from_slice(&[1_i32, 2, 3]).unwrap().reshape(&[3]).unwrap();
+
+        let err = eq(&lhs, &rhs).unwrap_err();
+        assert!(matches!(err, MohuError::ShapeMismatch { .. }));
+    }
+}

--- a/crates/mohu-ops/src/cmp.rs
+++ b/crates/mohu-ops/src/cmp.rs
@@ -1,7 +1,7 @@
 use mohu_core::mohu_buffer::ops::parallel_zip;
 use mohu_core::mohu_buffer::Buffer;
 use mohu_core::mohu_dtype::{dispatch_dtype, dispatch_real, DType};
-use mohu_core::mohu_error::{MohuError, MohuResult};
+use mohu_core::mohu_error::{bail, ensure, MohuError, MohuResult, ResultExt};
 
 use crate::broadcast::broadcast_binary_inputs;
 
@@ -33,21 +33,24 @@ impl CmpKind {
 }
 
 fn compare_binary(lhs: &Buffer, rhs: &Buffer, kind: CmpKind) -> MohuResult<Buffer> {
-    if lhs.dtype() != rhs.dtype() {
-        return Err(MohuError::DTypeMismatch {
+    ensure!(
+        lhs.dtype() == rhs.dtype(),
+        MohuError::DTypeMismatch {
             expected: lhs.dtype().to_string(),
             got:      rhs.dtype().to_string(),
-        });
-    }
+        }
+    );
     if kind.is_ordered() && lhs.dtype().is_complex() {
-        return Err(MohuError::domain(
+        bail!(MohuError::domain(
             kind.name(),
             "ordered comparisons are undefined for complex dtypes",
         ));
     }
 
-    let (lhs_buf, rhs_buf, out_shape) = broadcast_binary_inputs(lhs, rhs)?;
-    let mut out = Buffer::zeros(DType::Bool, &out_shape)?;
+    let (lhs_buf, rhs_buf, out_shape) = broadcast_binary_inputs(lhs, rhs)
+        .with_context(|| format!("cmp::{} broadcast inputs", kind.name()))?;
+    let mut out = Buffer::zeros(DType::Bool, &out_shape)
+        .with_context(|| format!("cmp::{} allocate bool output", kind.name()))?;
 
     match kind {
         CmpKind::Eq => {
@@ -56,7 +59,13 @@ fn compare_binary(lhs: &Buffer, rhs: &Buffer, kind: CmpKind) -> MohuResult<Buffe
                     parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a == b)
                 };
             }
-            dispatch_dtype!(lhs.dtype(), do_cmp)?;
+            dispatch_dtype!(lhs.dtype(), do_cmp).with_context(|| {
+                format!(
+                    "cmp::{} execute dtype dispatch for {}",
+                    kind.name(),
+                    lhs.dtype()
+                )
+            })?;
         }
         CmpKind::Ne => {
             macro_rules! do_cmp {
@@ -64,54 +73,96 @@ fn compare_binary(lhs: &Buffer, rhs: &Buffer, kind: CmpKind) -> MohuResult<Buffe
                     parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a != b)
                 };
             }
-            dispatch_dtype!(lhs.dtype(), do_cmp)?;
+            dispatch_dtype!(lhs.dtype(), do_cmp).with_context(|| {
+                format!(
+                    "cmp::{} execute dtype dispatch for {}",
+                    kind.name(),
+                    lhs.dtype()
+                )
+            })?;
         }
         CmpKind::Lt => {
             if lhs.dtype() == DType::Bool {
-                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a < b)?;
+                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a < b)
+                    .with_context(|| format!("cmp::{} execute bool kernel", kind.name()))?;
             } else {
                 macro_rules! do_cmp {
                     ($T:ty) => {
                         parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a < b)
                     };
                 }
-                dispatch_real!(lhs.dtype(), do_cmp)??;
+                dispatch_real!(lhs.dtype(), do_cmp)
+                    .with_context(|| {
+                        format!(
+                            "cmp::{} select real dispatch for {}",
+                            kind.name(),
+                            lhs.dtype()
+                        )
+                    })?
+                    .with_context(|| format!("cmp::{} execute real kernel", kind.name()))?;
             }
         }
         CmpKind::Le => {
             if lhs.dtype() == DType::Bool {
-                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a <= b)?;
+                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a <= b)
+                    .with_context(|| format!("cmp::{} execute bool kernel", kind.name()))?;
             } else {
                 macro_rules! do_cmp {
                     ($T:ty) => {
                         parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a <= b)
                     };
                 }
-                dispatch_real!(lhs.dtype(), do_cmp)??;
+                dispatch_real!(lhs.dtype(), do_cmp)
+                    .with_context(|| {
+                        format!(
+                            "cmp::{} select real dispatch for {}",
+                            kind.name(),
+                            lhs.dtype()
+                        )
+                    })?
+                    .with_context(|| format!("cmp::{} execute real kernel", kind.name()))?;
             }
         }
         CmpKind::Gt => {
             if lhs.dtype() == DType::Bool {
-                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a > b)?;
+                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a > b)
+                    .with_context(|| format!("cmp::{} execute bool kernel", kind.name()))?;
             } else {
                 macro_rules! do_cmp {
                     ($T:ty) => {
                         parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a > b)
                     };
                 }
-                dispatch_real!(lhs.dtype(), do_cmp)??;
+                dispatch_real!(lhs.dtype(), do_cmp)
+                    .with_context(|| {
+                        format!(
+                            "cmp::{} select real dispatch for {}",
+                            kind.name(),
+                            lhs.dtype()
+                        )
+                    })?
+                    .with_context(|| format!("cmp::{} execute real kernel", kind.name()))?;
             }
         }
         CmpKind::Ge => {
             if lhs.dtype() == DType::Bool {
-                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a >= b)?;
+                parallel_zip::<bool, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a >= b)
+                    .with_context(|| format!("cmp::{} execute bool kernel", kind.name()))?;
             } else {
                 macro_rules! do_cmp {
                     ($T:ty) => {
                         parallel_zip::<$T, bool, _>(&lhs_buf, &rhs_buf, &mut out, |a, b| a >= b)
                     };
                 }
-                dispatch_real!(lhs.dtype(), do_cmp)??;
+                dispatch_real!(lhs.dtype(), do_cmp)
+                    .with_context(|| {
+                        format!(
+                            "cmp::{} select real dispatch for {}",
+                            kind.name(),
+                            lhs.dtype()
+                        )
+                    })?
+                    .with_context(|| format!("cmp::{} execute real kernel", kind.name()))?;
             }
         }
     }
@@ -321,6 +372,11 @@ mod tests {
         let rhs = Buffer::from_slice(&[1_i32, 2, 3]).unwrap().reshape(&[3]).unwrap();
 
         let err = eq(&lhs, &rhs).unwrap_err();
-        assert!(matches!(err, MohuError::ShapeMismatch { .. }));
+        match err {
+            MohuError::Context { source, .. } => {
+                assert!(matches!(*source, MohuError::ShapeMismatch { .. }));
+            }
+            other => panic!("expected context-wrapped ShapeMismatch, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## What

Implements element-wise comparison operations in `mohu-ops`:

- `eq`, `ne`, `lt`, `le`, `gt`, `ge` in `crates/mohu-ops/src/cmp.rs`
- Bool output buffer (`DType::Bool`) for all comparison ops
- Unit tests for bool output, broadcast behavior, IEEE-754 NaN semantics, complex ordered-comparison domain errors, and mismatch errors

## Why
Closes #135

## How

- Added one shared comparison implementation for all six ops
- Ensured comparisons broadcast correctly, always return `Bool`, and reject ordered complex comparisons with `DomainError`.
- Added tests for broadcast behavior, NaN semantics, and expected error cases.

## Checklist

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all` applied
- [ ] `CHANGELOG.md` updated (if user-facing change)
- [ ] Benchmarks added or updated (if performance-sensitive path)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added element-wise comparison ops: eq, ne, lt, le, gt, ge — produce boolean results and auto-broadcast inputs for seamless tensor comparisons.
  * Improved broadcasting logic to share buffers when shapes already match and ensure contiguous outputs for efficient comparisons.
  * Ordered comparisons will error for complex-number inputs to enforce valid semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->