### PR TITLE
feat(index): implement boolean mask and fancy indexing

### DIFF
--- a/crates/mohu-index/src/boolean.rs
+++ b/crates/mohu-index/src/boolean.rs
@@ -1,1 +1,44 @@
-// boolean — implementation pending
+use mohu_buffer::{Buffer, layout::Order};
+use mohu_dtype::dtype::DType;
+use mohu_error::{MohuError, MohuResult};
+
+/// Extracts elements from `src` corresponding to `true` values in `mask`.
+pub fn index_bool(src: &Buffer, mask: &Buffer) -> MohuResult<Buffer> {
+    if mask.dtype() != DType::Bool {
+        return Err(MohuError::domain("index_bool", "mask must be bool"));
+    }
+    if mask.shape() != src.shape() {
+        return Err(MohuError::ShapeMismatch {
+            expected: src.shape().to_vec(),
+            got: mask.shape().to_vec(),
+        });
+    }
+
+    let mask_contig = mask.to_contiguous()?;
+    let mask_slice = mask_contig.as_slice::<bool>()?;
+
+    let src_contig = src.to_contiguous()?;
+    let itemsize = src_contig.itemsize();
+    let src_ptr = src_contig.as_ptr();
+
+    let count = mask_slice.iter().filter(|&&b| b).count();
+
+    let mut out = Buffer::alloc(src.dtype(), &[count], Order::C)?;
+    let out_ptr = unsafe { out.as_mut_ptr() };
+
+    let mut out_idx = 0;
+    for (i, &b) in mask_slice.iter().enumerate() {
+        if b {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    src_ptr.add(i * itemsize),
+                    out_ptr.add(out_idx * itemsize),
+                    itemsize,
+                );
+            }
+            out_idx += 1;
+        }
+    }
+
+    Ok(out)
+}

--- a/crates/mohu-index/src/lib.rs
+++ b/crates/mohu-index/src/lib.rs
@@ -30,4 +30,7 @@ pub mod slice;
 pub mod take;
 pub mod where_op;
 
+pub use boolean::index_bool;
+pub use take::index_take;
+
 pub use mohu_error::{MohuError, MohuResult};

--- a/crates/mohu-index/src/take.rs
+++ b/crates/mohu-index/src/take.rs
@@ -1,1 +1,72 @@
-// take — implementation pending
+use mohu_buffer::{
+    layout::Order,
+    strides::{ravel_multi_index, NdIndexIter},
+    Buffer,
+};
+use mohu_dtype::dtype::DType;
+use mohu_error::{MohuError, MohuResult};
+
+/// Selects elements along `axis` at positions given by `indices`.
+pub fn index_take(src: &Buffer, indices: &Buffer, axis: usize) -> MohuResult<Buffer> {
+    if indices.dtype() != DType::I64 {
+        return Err(MohuError::domain("index_take", "indices must be i64"));
+    }
+    if axis >= src.ndim() {
+        return Err(MohuError::AxisOutOfRange {
+            axis: axis as i64,
+            ndim: src.ndim(),
+            valid: format!("0..{}", src.ndim()),
+        });
+    }
+
+    let indices_contig = indices.to_contiguous()?;
+    let indices_slice = indices_contig.as_slice::<i64>()?;
+
+    let axis_size = src.shape()[axis] as i64;
+    for &idx in indices_slice {
+        if idx < 0 || idx >= axis_size {
+            return Err(MohuError::IndexOutOfBounds {
+                index: idx,
+                axis,
+                size: src.shape()[axis],
+            });
+        }
+    }
+
+    let mut out_shape = Vec::with_capacity(src.ndim() - 1 + indices.ndim());
+    out_shape.extend_from_slice(&src.shape()[..axis]);
+    out_shape.extend_from_slice(indices.shape());
+    out_shape.extend_from_slice(&src.shape()[axis + 1..]);
+
+    let mut out = Buffer::alloc(src.dtype(), &out_shape, Order::C)?;
+    let out_ptr = unsafe { out.as_mut_ptr() };
+
+    let src_contig = src.to_contiguous()?;
+    let src_ptr = src_contig.as_ptr();
+    let itemsize = src_contig.itemsize();
+
+    let out_iter = NdIndexIter::new(&out_shape);
+    for (out_flat_idx, out_coord) in out_iter.enumerate() {
+        let mut src_coord = Vec::with_capacity(src.ndim());
+        src_coord.extend_from_slice(&out_coord[..axis]);
+
+        let indices_coord = &out_coord[axis..axis + indices.ndim()];
+        let indices_flat_idx = ravel_multi_index(indices_coord, indices.shape())?;
+        let src_axis_idx = indices_slice[indices_flat_idx] as usize;
+
+        src_coord.push(src_axis_idx);
+        src_coord.extend_from_slice(&out_coord[axis + indices.ndim()..]);
+
+        let src_flat_idx = ravel_multi_index(&src_coord, src.shape())?;
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                src_ptr.add(src_flat_idx * itemsize),
+                out_ptr.add(out_flat_idx * itemsize),
+                itemsize,
+            );
+        }
+    }
+
+    Ok(out)
+}

--- a/crates/mohu-index/tests/test_indexing.rs
+++ b/crates/mohu-index/tests/test_indexing.rs
@@ -1,0 +1,69 @@
+use mohu_buffer::Buffer;
+use mohu_dtype::dtype::DType;
+use mohu_index::{index_bool, index_take, MohuError};
+
+#[test]
+fn test_index_bool() {
+    let src = Buffer::from_slice(&[10i32, 20, 30, 40]).unwrap();
+    let mask = Buffer::from_slice(&[true, false, true, false]).unwrap();
+    
+    let result = index_bool(&src, &mask).unwrap();
+    assert_eq!(result.shape(), &[2]);
+    assert_eq!(result.as_slice::<i32>().unwrap(), &[10, 30]);
+}
+
+#[test]
+fn test_index_bool_errors() {
+    let src = Buffer::from_slice(&[10i32, 20, 30, 40]).unwrap();
+    
+    // DomainError for non-bool mask
+    let mask = Buffer::from_slice(&[1i32, 0, 1, 0]).unwrap();
+    assert!(matches!(index_bool(&src, &mask), Err(MohuError::DomainError { .. })));
+
+    // ShapeMismatch
+    let mask2 = Buffer::from_slice(&[true, false]).unwrap();
+    assert!(matches!(index_bool(&src, &mask2), Err(MohuError::ShapeMismatch { .. })));
+}
+
+#[test]
+fn test_index_take() {
+    // 2D src: shape (2, 3)
+    let src = Buffer::from_slice_2d(&[
+        &[1i32, 2, 3][..],
+        &[4, 5, 6][..],
+    ]).unwrap();
+
+    // indices: shape (2,)
+    let indices = Buffer::from_slice(&[1i64, 0]).unwrap();
+
+    // take along axis 0
+    let result = index_take(&src, &indices, 0).unwrap();
+    assert_eq!(result.shape(), &[2, 3]);
+    let slice = result.as_slice::<i32>().unwrap();
+    assert_eq!(slice, &[4, 5, 6, 1, 2, 3]);
+
+    // take along axis 1
+    let result2 = index_take(&src, &indices, 1).unwrap();
+    assert_eq!(result2.shape(), &[2, 2]);
+    let slice2 = result2.as_slice::<i32>().unwrap();
+    // expected: row 0: indices 1, 0 -> 2, 1
+    //           row 1: indices 1, 0 -> 5, 4
+    assert_eq!(slice2, &[2, 1, 5, 4]);
+}
+
+#[test]
+fn test_index_take_errors() {
+    let src = Buffer::from_slice(&[10i32, 20, 30]).unwrap();
+    
+    let wrong_dtype = Buffer::from_slice(&[1i32, 0]).unwrap();
+    assert!(matches!(index_take(&src, &wrong_dtype, 0), Err(MohuError::DomainError { .. })));
+
+    let indices = Buffer::from_slice(&[1i64, 3]).unwrap();
+    assert!(matches!(index_take(&src, &indices, 0), Err(MohuError::IndexOutOfBounds { .. })));
+
+    let indices_neg = Buffer::from_slice(&[1i64, -1]).unwrap();
+    assert!(matches!(index_take(&src, &indices_neg, 0), Err(MohuError::IndexOutOfBounds { .. })));
+
+    let valid_indices = Buffer::from_slice(&[1i64, 0]).unwrap();
+    assert!(matches!(index_take(&src, &valid_indices, 1), Err(MohuError::AxisOutOfRange { .. })));
+}


### PR DESCRIPTION


## Summary

Implements boolean mask indexing and integer array (fancy) indexing for `mohu-index`, closing the two most common advanced indexing patterns.

## Changes

### `crates/mohu-index/src/boolean.rs`
- Implements `pub fn index_bool(src: &Buffer, mask: &Buffer) -> MohuResult<Buffer>`
- Validates `mask` dtype is `DType::Bool` (returns `DomainError` otherwise)
- Validates `mask.shape() == src.shape()` (returns `ShapeMismatch` otherwise)
- Returns a new owning 1D buffer containing only the elements where mask is `true`

### `crates/mohu-index/src/take.rs`
- Implements `pub fn index_take(src: &Buffer, indices: &Buffer, axis: usize) -> MohuResult<Buffer>`
- Validates `indices` dtype is `DType::I64` (returns `DomainError` otherwise)
- Validates `axis` is in range (returns `AxisOutOfRange` otherwise)
- Returns `IndexOutOfBounds` for any out-of-range or negative index
- Negative indices not supported in v1 (treated as out-of-bounds)
- Output shape is `src_shape[..axis] + indices.shape() + src_shape[axis+1..]`

### `crates/mohu-index/src/lib.rs`
- Exports `index_bool` and `index_take` as public API

### `crates/mohu-index/tests/test_indexing.rs`
- Integration tests for `index_bool`: 1D extraction, error cases (wrong dtype, shape mismatch)
- Integration tests for `index_take`: 1D and 2D gathering along both axes, error cases (wrong dtype, out-of-bounds, negative index, invalid axis)

## Acceptance Criteria

- [x] `index_bool` extracts correct elements for 1D and 2D mask
- [x] `index_take` gathers correct rows/cols for 1D and 2D src
- [x] All error cases tested
- [x] Output is always a new owning buffer (no view aliasing)
- [x] No `.unwrap()` in library code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Boolean indexing for filtering arrays using boolean masks
  * Axis-based take operation for selecting elements along specified dimensions

* **Tests**
  * Comprehensive test coverage for new indexing operations, including edge cases and error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->