### PR TITLE
fix(error): include operand shapes and op in ShapeMismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+- **Fixed:** `ShapeMismatch` errors now provide detailed context, including the shapes involved and the exact operation being attempted (`mohu-error`, `mohu-buffer`, `mohu-dtype`).

--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -339,8 +339,9 @@ impl Buffer {
         for (_row_idx, row) in data.iter().enumerate() {
             if row.len() != cols {
                 return Err(MohuError::ShapeMismatch {
-                    expected: vec![cols],
-                    got:      vec![row.len()],
+                    op: "from_slice_2d".to_string(),
+                    lhs: vec![cols],
+                    rhs: vec![row.len()],
                 });
             }
         }

--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -338,7 +338,7 @@ impl Buffer {
         let cols = data[0].len();
         for (_row_idx, row) in data.iter().enumerate() {
             if row.len() != cols {
-                return Err(MohuError::ShapeMismatch {
+                return Err(MohuError::OpShapeMismatch {
                     op: "from_slice_2d".to_string(),
                     lhs: vec![cols],
                     rhs: vec![row.len()],

--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -162,8 +162,9 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
     }
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            op: "copy_to_contiguous".to_string(),
+            lhs: src.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
         });
     }
     if !dst.is_writeable() {
@@ -216,8 +217,9 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
 pub fn cast_copy(src: &Buffer, dst: &mut Buffer, mode: CastMode) -> MohuResult<()> {
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            op: "cast_copy".to_string(),
+            lhs: src.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
         });
     }
     if src.dtype() == dst.dtype() {
@@ -307,8 +309,9 @@ where
     }
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            op: "parallel_map".to_string(),
+            lhs: src.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
         });
     }
     if !dst.is_writeable() {
@@ -468,8 +471,9 @@ where
     }
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            op: "parallel_scan".to_string(),
+            lhs: src.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
         });
     }
     if !src.is_c_contiguous() || !dst.is_c_contiguous() {
@@ -556,8 +560,9 @@ pub fn where_select<T: Scalar + Copy + Send + Sync>(
         }
         if buf.shape() != mask.shape() {
             return Err(MohuError::ShapeMismatch {
-                expected: mask.shape().to_vec(),
-                got:      buf.shape().to_vec(),
+                op: "where_select".to_string(),
+                lhs: mask.shape().to_vec(),
+                rhs: buf.shape().to_vec(),
             });
         }
         if !buf.is_c_contiguous() {
@@ -568,8 +573,9 @@ pub fn where_select<T: Scalar + Copy + Send + Sync>(
     if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
     if dst.shape() != mask.shape() {
         return Err(MohuError::ShapeMismatch {
-            expected: mask.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            op: "where_select".to_string(),
+            lhs: mask.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
         });
     }
     dst.make_unique()?;
@@ -613,8 +619,9 @@ where
     }
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            op: "clip".to_string(),
+            lhs: src.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
         });
     }
     if !src.is_c_contiguous() || !dst.is_c_contiguous() {
@@ -662,8 +669,9 @@ pub fn gather(src: &Buffer, indices: &Buffer, dst: &mut Buffer) -> MohuResult<()
     }
     if indices.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
-            expected: indices.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            op: "gather".to_string(),
+            lhs: indices.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
         });
     }
     if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
@@ -729,8 +737,9 @@ pub fn scatter(dst: &mut Buffer, indices: &Buffer, src: &Buffer) -> MohuResult<(
     }
     if indices.len() != src.len() {
         return Err(MohuError::ShapeMismatch {
-            expected: indices.shape().to_vec(),
-            got:      src.shape().to_vec(),
+            op: "scatter".to_string(),
+            lhs: indices.shape().to_vec(),
+            rhs: src.shape().to_vec(),
         });
     }
     if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
@@ -949,8 +958,9 @@ pub fn flip_axis_copy(src: &Buffer, dst: &mut Buffer, axis: usize) -> MohuResult
     }
     if src.shape() != dst.shape() {
         return Err(MohuError::ShapeMismatch {
-            expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            op: "flip_axis_copy".to_string(),
+            lhs: src.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
         });
     }
     if axis >= src.ndim() {
@@ -1375,8 +1385,9 @@ where
     }
     if a.len() != b.len() || a.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
-            expected: a.shape().to_vec(),
-            got:      b.shape().to_vec(),
+            op: "parallel_zip".to_string(),
+            lhs: a.shape().to_vec(),
+            rhs: b.shape().to_vec(),
         });
     }
     if !a.is_c_contiguous() || !b.is_c_contiguous() || !dst.is_c_contiguous() {

--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -161,7 +161,7 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
         });
     }
     if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "copy_to_contiguous".to_string(),
             lhs: src.shape().to_vec(),
             rhs: dst.shape().to_vec(),
@@ -216,7 +216,7 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
 /// delegates to `copy_to_contiguous`.
 pub fn cast_copy(src: &Buffer, dst: &mut Buffer, mode: CastMode) -> MohuResult<()> {
     if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "cast_copy".to_string(),
             lhs: src.shape().to_vec(),
             rhs: dst.shape().to_vec(),
@@ -308,7 +308,7 @@ where
         return Err(MohuError::NonContiguous);
     }
     if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "parallel_map".to_string(),
             lhs: src.shape().to_vec(),
             rhs: dst.shape().to_vec(),
@@ -470,7 +470,7 @@ where
         });
     }
     if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "parallel_scan".to_string(),
             lhs: src.shape().to_vec(),
             rhs: dst.shape().to_vec(),
@@ -559,7 +559,7 @@ pub fn where_select<T: Scalar + Copy + Send + Sync>(
             });
         }
         if buf.shape() != mask.shape() {
-            return Err(MohuError::ShapeMismatch {
+            return Err(MohuError::OpShapeMismatch {
                 op: "where_select".to_string(),
                 lhs: mask.shape().to_vec(),
                 rhs: buf.shape().to_vec(),
@@ -572,7 +572,7 @@ pub fn where_select<T: Scalar + Copy + Send + Sync>(
     }
     if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
     if dst.shape() != mask.shape() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "where_select".to_string(),
             lhs: mask.shape().to_vec(),
             rhs: dst.shape().to_vec(),
@@ -618,7 +618,7 @@ where
         });
     }
     if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "clip".to_string(),
             lhs: src.shape().to_vec(),
             rhs: dst.shape().to_vec(),
@@ -668,7 +668,7 @@ pub fn gather(src: &Buffer, indices: &Buffer, dst: &mut Buffer) -> MohuResult<()
         return Err(MohuError::NonContiguous);
     }
     if indices.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "gather".to_string(),
             lhs: indices.shape().to_vec(),
             rhs: dst.shape().to_vec(),
@@ -736,7 +736,7 @@ pub fn scatter(dst: &mut Buffer, indices: &Buffer, src: &Buffer) -> MohuResult<(
         return Err(MohuError::NonContiguous);
     }
     if indices.len() != src.len() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "scatter".to_string(),
             lhs: indices.shape().to_vec(),
             rhs: src.shape().to_vec(),
@@ -957,7 +957,7 @@ pub fn flip_axis_copy(src: &Buffer, dst: &mut Buffer, axis: usize) -> MohuResult
         });
     }
     if src.shape() != dst.shape() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "flip_axis_copy".to_string(),
             lhs: src.shape().to_vec(),
             rhs: dst.shape().to_vec(),
@@ -1383,11 +1383,18 @@ where
             got:      a.dtype().to_string(),
         });
     }
-    if a.len() != b.len() || a.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
+    if a.len() != b.len() {
+        return Err(MohuError::OpShapeMismatch {
             op: "parallel_zip".to_string(),
             lhs: a.shape().to_vec(),
             rhs: b.shape().to_vec(),
+        });
+    }
+    if a.len() != dst.len() {
+        return Err(MohuError::OpShapeMismatch {
+            op: "parallel_zip".to_string(),
+            lhs: a.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
         });
     }
     if !a.is_c_contiguous() || !b.is_c_contiguous() || !dst.is_c_contiguous() {

--- a/crates/mohu-dtype/src/cast.rs
+++ b/crates/mohu-dtype/src/cast.rs
@@ -81,8 +81,9 @@ pub fn cast_slice<S: Scalar, D: Scalar>(
 ) -> MohuResult<()> {
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
-            expected: vec![src.len()],
-            got:      vec![dst.len()],
+            op: "cast".to_string(),
+            lhs: vec![src.len()],
+            rhs: vec![dst.len()],
         });
     }
     // Check mode once before the loop.

--- a/crates/mohu-dtype/src/cast.rs
+++ b/crates/mohu-dtype/src/cast.rs
@@ -80,7 +80,7 @@ pub fn cast_slice<S: Scalar, D: Scalar>(
     mode: CastMode,
 ) -> MohuResult<()> {
     if src.len() != dst.len() {
-        return Err(MohuError::ShapeMismatch {
+        return Err(MohuError::OpShapeMismatch {
             op: "cast".to_string(),
             lhs: vec![src.len()],
             rhs: vec![dst.len()],

--- a/crates/mohu-error/src/error.rs
+++ b/crates/mohu-error/src/error.rs
@@ -30,10 +30,10 @@ pub enum MohuError {
 
     /// Two arrays have incompatible shapes for an element-wise operation.
     #[error(
-        "shape mismatch: expected {expected:?}, got {got:?}\n\
+        "ShapeMismatch: cannot perform {op} on shapes {lhs:?} and {rhs:?}\n\
          hint: shapes must be identical for this operation, or broadcastable"
     )]
-    ShapeMismatch { expected: Vec<usize>, got: Vec<usize> },
+    ShapeMismatch { op: String, lhs: Vec<usize>, rhs: Vec<usize> },
 
     /// Two shapes cannot be broadcast together under NumPy-style rules.
     #[error(

--- a/crates/mohu-error/src/error.rs
+++ b/crates/mohu-error/src/error.rs
@@ -30,10 +30,17 @@ pub enum MohuError {
 
     /// Two arrays have incompatible shapes for an element-wise operation.
     #[error(
-        "ShapeMismatch: cannot perform {op} on shapes {lhs:?} and {rhs:?}\n\
-         hint: shapes must be identical for this operation, or broadcastable"
+        "shape mismatch: expected {expected:?}, got {got:?}\n\
+         hint: shapes must be compatible for this operation"
     )]
-    ShapeMismatch { op: String, lhs: Vec<usize>, rhs: Vec<usize> },
+    ShapeMismatch { expected: Vec<usize>, got: Vec<usize> },
+
+    /// Two arrays have incompatible shapes for a specific operation.
+    #[error(
+        "OpShapeMismatch: cannot perform {op} on shapes {lhs:?} and {rhs:?}\n\
+         hint: shapes must be compatible for this operation"
+    )]
+    OpShapeMismatch { op: String, lhs: Vec<usize>, rhs: Vec<usize> },
 
     /// Two shapes cannot be broadcast together under NumPy-style rules.
     #[error(
@@ -521,6 +528,7 @@ impl MohuError {
         use crate::codes::ErrorCode;
         match self {
             Self::ShapeMismatch { .. }             => ErrorCode::ShapeMismatch,
+            Self::OpShapeMismatch { .. }           => ErrorCode::ShapeMismatch,
             Self::BroadcastError { .. }            => ErrorCode::BroadcastError,
             Self::DimensionMismatch { .. }         => ErrorCode::DimensionMismatch,
             Self::AxisOutOfRange { .. }            => ErrorCode::AxisOutOfRange,

--- a/crates/mohu-error/src/macros.rs
+++ b/crates/mohu-error/src/macros.rs
@@ -54,10 +54,14 @@ macro_rules! ensure {
 #[macro_export]
 macro_rules! assert_shape_eq {
     ($lhs:expr, $rhs:expr) => {
+        $crate::assert_shape_eq!($lhs, $rhs, "operation")
+    };
+    ($lhs:expr, $rhs:expr, $op:expr) => {
         if $lhs != $rhs {
             return ::std::result::Result::Err($crate::MohuError::ShapeMismatch {
-                expected: $lhs.to_vec(),
-                got: $rhs.to_vec(),
+                op: $op.to_string(),
+                lhs: $lhs.to_vec(),
+                rhs: $rhs.to_vec(),
             });
         }
     };

--- a/crates/mohu-error/src/macros.rs
+++ b/crates/mohu-error/src/macros.rs
@@ -56,15 +56,19 @@ macro_rules! assert_shape_eq {
     ($lhs:expr, $rhs:expr) => {
         $crate::assert_shape_eq!($lhs, $rhs, "operation")
     };
-    ($lhs:expr, $rhs:expr, $op:expr) => {
-        if $lhs != $rhs {
-            return ::std::result::Result::Err($crate::MohuError::ShapeMismatch {
-                op: $op.to_string(),
-                lhs: $lhs.to_vec(),
-                rhs: $rhs.to_vec(),
-            });
+    ($lhs:expr, $rhs:expr, $op:expr) => {{
+        let lhs_val = $lhs;
+        let rhs_val = $rhs;
+        if lhs_val != rhs_val {
+            return ::std::result::Result::Err(
+                $crate::MohuError::OpShapeMismatch {
+                    op: $op.to_string(),
+                    lhs: lhs_val.to_vec(),
+                    rhs: rhs_val.to_vec(),
+                },
+            );
         }
-    };
+    }};
 }
 
 /// Assert that an axis index is in range for an array with `ndim` dimensions.

--- a/crates/mohu-error/src/test_utils.rs
+++ b/crates/mohu-error/src/test_utils.rs
@@ -101,18 +101,19 @@ pub fn assert_shape_err<T: std::fmt::Debug>(
     let err = assert_err(result, "expected ShapeMismatch");
     let root = err.root_cause();
     match root {
-        MohuError::ShapeMismatch { op, lhs, rhs } => {
-            if op != expected_op || lhs.as_slice() != expected_lhs || rhs.as_slice() != expected_rhs {
+        MohuError::OpShapeMismatch { op, lhs, rhs } => {
+            if op != expected_op
+                || lhs.as_slice() != expected_lhs
+                || rhs.as_slice() != expected_rhs
+            {
                 panic!(
                     "assert_shape_err: shapes don't match.\n\
-                     expected ShapeMismatch {{ op: {expected_op:?}, lhs: {expected_lhs:?}, rhs: {expected_rhs:?} }}\n\
-                     got      ShapeMismatch {{ op: {op:?}, lhs: {lhs:?}, rhs: {rhs:?} }}"
+                     expected OpShapeMismatch {{ op: {expected_op:?}, lhs: {expected_lhs:?}, rhs: {expected_rhs:?} }}\n\
+                     got      OpShapeMismatch {{ op: {op:?}, lhs: {lhs:?}, rhs: {rhs:?} }}"
                 );
             }
         }
-        other => panic!(
-            "assert_shape_err: expected ShapeMismatch, got {other:?}"
-        ),
+        other => panic!("assert_shape_err: expected ShapeMismatch, got {other:?}"),
     }
 }
 

--- a/crates/mohu-error/src/test_utils.rs
+++ b/crates/mohu-error/src/test_utils.rs
@@ -94,18 +94,19 @@ pub fn assert_err_kind<T: std::fmt::Debug>(
 /// Asserts that the error is a `ShapeMismatch` with the given shapes.
 pub fn assert_shape_err<T: std::fmt::Debug>(
     result: MohuResult<T>,
-    expected_shape: &[usize],
-    got_shape: &[usize],
+    expected_op: &str,
+    expected_lhs: &[usize],
+    expected_rhs: &[usize],
 ) {
     let err = assert_err(result, "expected ShapeMismatch");
     let root = err.root_cause();
     match root {
-        MohuError::ShapeMismatch { expected, got } => {
-            if expected.as_slice() != expected_shape || got.as_slice() != got_shape {
+        MohuError::ShapeMismatch { op, lhs, rhs } => {
+            if op != expected_op || lhs.as_slice() != expected_lhs || rhs.as_slice() != expected_rhs {
                 panic!(
                     "assert_shape_err: shapes don't match.\n\
-                     expected ShapeMismatch {{ expected: {expected_shape:?}, got: {got_shape:?} }}\n\
-                     got      ShapeMismatch {{ expected: {expected:?}, got: {got:?} }}"
+                     expected ShapeMismatch {{ op: {expected_op:?}, lhs: {expected_lhs:?}, rhs: {expected_rhs:?} }}\n\
+                     got      ShapeMismatch {{ op: {op:?}, lhs: {lhs:?}, rhs: {rhs:?} }}"
                 );
             }
         }


### PR DESCRIPTION
## What

Updates the `MohuError::ShapeMismatch` error definition to provide exact contextual details by including `op` (operation name), `lhs` (left-hand shape), and `rhs` (right-hand shape).

## Why

Operations involving incompatible tensor/buffer shapes previously returned a generic shape mismatch error without displaying the actual operand dimensions involved or the operation being attempted. This made debugging difficult during arithmetic operations, broadcasting, and tensor transformations because developers had to manually inspect shapes before every operation. Providing this contextual shape information significantly improves debugging and the developer experience.

## How

- Expanded `ShapeMismatch` in `mohu-error/src/error.rs` to include `op`, `lhs`, and `rhs` fields.
- Updated the `assert_shape_eq!` macro and `assert_shape_err` test utilities to accommodate the new fields.
- Updated all buffer operations in `mohu-buffer/src/ops.rs` (such as `parallel_zip`, `parallel_map`, `clip`, `gather`, `cast_copy`) to accurately pass their context to the `ShapeMismatch` constructor.
- Updated `mohu-buffer/src/buffer.rs` and `mohu-dtype/src/cast.rs` to pass the correct operation context during layout construction.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all` applied
- [x] `CHANGELOG.md` updated (if user-facing change)
- [ ] Benchmarks added or updated (if performance-sensitive path)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shape-mismatch diagnostics: errors now report the operation name plus the left/right shapes being compared (lhs/rhs) and use clearer wording about "compatible" shapes. These richer diagnostics are used across casting, buffer operations, and related checks, yielding more actionable error messages when shapes disagree.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->