### PR TITLE
feat(array): implement NdArray construction and metadata accessors

### DIFF
--- a/crates/mohu-array/src/array.rs
+++ b/crates/mohu-array/src/array.rs
@@ -1,0 +1,89 @@
+use std::marker::PhantomData;
+
+use mohu_buffer::Buffer;
+use mohu_dtype::{DType, Scalar};
+use mohu_error::MohuResult;
+
+pub trait MohuElement: Scalar {}
+
+impl<T: Scalar> MohuElement for T {}
+
+pub struct NdArray<T: MohuElement> {
+    buffer: Buffer,
+    _marker: PhantomData<T>,
+}
+
+impl<T: MohuElement> NdArray<T> {
+    pub fn zeros(shape: &[usize]) -> MohuResult<Self> {
+        Ok(Self {
+            buffer: Buffer::zeros(T::DTYPE, shape)?,
+            _marker: PhantomData,
+        })
+    }
+
+    pub fn ones(shape: &[usize]) -> MohuResult<Self> {
+        Ok(Self {
+            buffer: Buffer::ones(T::DTYPE, shape)?,
+            _marker: PhantomData,
+        })
+    }
+
+    pub fn from_slice(data: &[T]) -> MohuResult<Self> {
+        Ok(Self {
+            buffer: Buffer::from_slice(data)?,
+            _marker: PhantomData,
+        })
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        self.buffer.shape()
+    }
+
+    pub fn ndim(&self) -> usize {
+        self.buffer.ndim()
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    pub fn dtype(&self) -> DType {
+        self.buffer.dtype()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NdArray;
+
+    #[test]
+    fn zeros_shapes_and_values() {
+        let array = NdArray::<f64>::zeros(&[3, 4]).unwrap();
+        assert_eq!(array.shape(), &[3, 4]);
+        assert_eq!(array.ndim(), 2);
+        assert_eq!(array.len(), 12);
+        assert!(!array.is_empty());
+        assert_eq!(array.dtype(), mohu_dtype::DType::F64);
+        let values = array.buffer.as_slice::<f64>().unwrap();
+        assert!(values.iter().all(|&value| value == 0.0));
+    }
+
+    #[test]
+    fn ones_and_from_slice() {
+        let ones = NdArray::<f32>::ones(&[2, 3]).unwrap();
+        let ones_values = ones.buffer.as_slice::<f32>().unwrap();
+        assert!(ones_values.iter().all(|&value| value == 1.0));
+
+        let array = NdArray::<f32>::from_slice(&[1.0, 2.0, 3.0]).unwrap();
+        assert_eq!(array.shape(), &[3]);
+        assert_eq!(array.ndim(), 1);
+        assert_eq!(array.len(), 3);
+        assert!(!array.is_empty());
+        assert_eq!(array.dtype(), mohu_dtype::DType::F32);
+        assert_eq!(array.buffer.as_slice::<f32>().unwrap(), &[1.0, 2.0, 3.0]);
+    }
+}

--- a/crates/mohu-array/src/lib.rs
+++ b/crates/mohu-array/src/lib.rs
@@ -3,3 +3,5 @@ pub mod iter;
 pub mod shape;
 pub mod slice;
 pub mod view;
+
+pub use array::{MohuElement, NdArray};


### PR DESCRIPTION
## What

Implemented Part 1 of `NdArray<T>` in the `mohu-array` crate.

### Changes made

- Added `MohuElement` trait using the existing `Scalar` trait
- Added `NdArray<T>` as a wrapper around `Buffer`
- Implemented the following APIs:
  - `zeros()`
  - `ones()`
  - `from_slice()`
  - `shape()`
  - `ndim()`
  - `len()`
  - `is_empty()`
  - `dtype()`
- Re-exported `NdArray` and `MohuElement` from the crate root
- Added unit tests for constructors and metadata accessors

---

## Why

Issue #151 requests the initial implementation of the user-facing `NdArray<T>` type.

This PR provides the basic construction methods and metadata accessors required for future array functionality while keeping the implementation consistent with the existing `Buffer`, `DType`, and error handling design.

Closes #151

---

## How

### NdArray structure

```rust
pub struct NdArray<T: MohuElement> {
    buffer: Buffer,
    _marker: PhantomData<T>,
}
```

### Implementation details

- Introduced `MohuElement` as a thin abstraction over `Scalar`
- Delegated construction methods to existing `Buffer` APIs:
  - `Buffer::zeros`
  - `Buffer::ones`
  - `Buffer::from_slice`
- Delegated metadata methods to the internal `Buffer`
- Used `T::DTYPE` for type-aware array creation
- Used `MohuResult` for error propagation
- No `.unwrap()` used in library code

### Tests added

- `NdArray::<f64>::zeros(&[3, 4])`
- `NdArray::<f32>::ones(&[2, 3])`
- `NdArray::<f32>::from_slice(&[1.0, 2.0, 3.0])`
- Shape validation
- N-dimensional validation
- Length validation
- Empty-state validation
- DType validation

---

## Validation

Successfully verified:

```bash
cargo check -p mohu-array
cargo test -p mohu-array
```

Output:

```text
running 2 tests
test array::tests::ones_and_from_slice ... ok
test array::tests::zeros_shapes_and_values ... ok

test result: ok. 2 passed; 0 failed
```

---

## Checklist

- [x] `cargo check -p mohu-array` passes
- [x] `cargo test -p mohu-array` passes
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all` applied
- [ ] `CHANGELOG.md` updated (not required for this change)
- [ ] Benchmarks added or updated (not applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a typed n-dimensional array with constructors for zeros, ones, and creating from data, plus read-only queries for shape, dimensions, length, emptiness, and element type.
* **Tests**
  * Added unit tests verifying creation, initialization values, and metadata for floating-point element types.
* **Chores**
  * Exposed the new array types at the crate's top-level API for easier consumption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->