### PR TITLE
docs: add system workflow diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,39 @@ No GIL. No single-threaded ops. No object overhead. Just arrays.
 NumPy is written in C and hasn't fundamentally changed in 20 years. It's single-threaded by default, its string arrays are an afterthought, and parallelism requires reaching for other tools. The Python data ecosystem deserves a better foundation.
 
 Polars proved you can rewrite the data layer in Rust and win. mohu is that same bet, one layer down.
+## system workflow
 
+The diagram below shows how Mohu processes data from Python through the Rust core engine and returns optimized results.
+ 
+```mermaid
+flowchart TD
+
+    A[Python Application] --> B[Python API Layer]
+
+    B --> C[PyO3 Bindings]
+
+    C --> D[Rust Core Engine]
+
+    D --> E[Rayon Parallel Execution]
+    D --> F[SIMD Optimizations]
+    D --> G[Apache Arrow Integration]
+
+    E --> H[High Performance Processing]
+    F --> H
+    G --> H
+
+    H --> I[Results Returned to Python]
+```
+
+### architecture overview
+
+1. **Python API Layer** provides a familiar Python interface for users.
+2. **PyO3 Bindings** bridge Python and Rust with minimal overhead.
+3. **Rust Core Engine** executes computationally intensive operations.
+4. **Rayon** enables automatic multi-core parallel execution.
+5. **SIMD Optimizations** accelerate vectorized numerical workloads.
+6. **Apache Arrow Integration** provides efficient columnar memory interoperability.
+7. Processed results are returned to Python with minimal copying.
 ## what's coming
 
 - N-dimensional arrays with a NumPy-compatible API


### PR DESCRIPTION
## What

Adds a new **System Workflow** section to the README with a Mermaid architecture diagram and accompanying documentation.

The new section visualizes:

* Python API layer
* PyO3 bindings
* Rust core engine
* Rayon-based parallel execution
* SIMD optimizations
* Apache Arrow interoperability
* Result flow back to Python

## Why

The README explains Mohu's goals and technology stack, but it lacks a visual overview of how the system components interact.

This change improves contributor onboarding by providing a clear architecture overview and making the Python ↔ Rust execution flow easier to understand.

Closes #156

## How

* Added a Mermaid workflow diagram to the README.
* Documented the role of each major component in the execution pipeline.
* Kept the documentation concise and aligned with the existing README style.
* Focused on readability for new contributors and first-time users.

## Checklist

* [x] Documentation-only change
* [ ] `cargo test --workspace` passes (not applicable)
* [ ] `cargo clippy --workspace -- -D warnings` passes (not applicable)
* [ ] `cargo fmt --all` applied (not applicable)
* [ ] `CHANGELOG.md` updated (not required)
* [ ] Benchmarks added or updated (not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with a comprehensive system workflow diagram that visually depicts the complete end-to-end data flow from Python applications through the API layer, PyO3 bindings, Rust core engine, and back to Python. Added an architecture overview section providing detailed information about each component's role and responsibilities in the overall system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->