### PR TITLE
fix(buffer): return error for integer division by zero

### DIFF
--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -17,7 +17,7 @@ use mohu_dtype::{
     promote::{CastMode, can_cast},
     scalar::Scalar,
 };
-use mohu_error::{MohuError, MohuResult};
+use mohu_error::{MohuError, MohuResult, bail};
 
 use crate::{buffer::Buffer, strides::StridedByteIter};
 
@@ -793,7 +793,7 @@ where
     T: Scalar + Copy + Send + Sync + std::ops::Div<Output = T>,
 {
     if T::DTYPE.is_integer() && scalar == T::ZERO {
-        return Err(MohuError::DivisionByZero);
+        bail!(MohuError::DivisionByZero);
     }
 
     parallel_inplace::<T, _>(buf, |x| x / scalar)

--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -792,6 +792,10 @@ pub fn div_scalar_inplace<T>(buf: &mut Buffer, scalar: T) -> MohuResult<()>
 where
     T: Scalar + Copy + Send + Sync + std::ops::Div<Output = T>,
 {
+    if T::DTYPE.is_integer() && scalar == T::ZERO {
+        return Err(MohuError::DivisionByZero);
+    }
+
     parallel_inplace::<T, _>(buf, |x| x / scalar)
 }
 

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -236,6 +236,16 @@ fn div_scalar_inplace_integer_zero_returns_error() {
     let err = ops::div_scalar_inplace(&mut buf, 0_i32).unwrap_err();
     assert!(matches!(err, MohuError::DivisionByZero));
     assert_eq!(buf.as_slice::<i32>().unwrap(), &[2, 4, 6]);
+
+    let mut buf = Buffer::from_slice(&[8_i64, 16, 24]).unwrap();
+    let err = ops::div_scalar_inplace(&mut buf, 0_i64).unwrap_err();
+    assert!(matches!(err, MohuError::DivisionByZero));
+    assert_eq!(buf.as_slice::<i64>().unwrap(), &[8, 16, 24]);
+
+    let mut buf = Buffer::from_slice(&[10_u32, 20, 30]).unwrap();
+    let err = ops::div_scalar_inplace(&mut buf, 0_u32).unwrap_err();
+    assert!(matches!(err, MohuError::DivisionByZero));
+    assert_eq!(buf.as_slice::<u32>().unwrap(), &[10, 20, 30]);
 }
 
 #[test]

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -5,6 +5,7 @@ use mohu_buffer::{
     strides::{NdIndexIter, broadcast_strides, c_strides, f_strides},
 };
 use mohu_dtype::{DType, promote::CastMode};
+use mohu_error::MohuError;
 
 // ── 1. Allocation ─────────────────────────────────────────────────────────────
 
@@ -227,6 +228,14 @@ fn fill_zero_clears_values() {
     let mut buf = Buffer::ones(DType::F64, &[100]).unwrap();
     ops::fill_zero(&mut buf).unwrap();
     assert!(buf.as_slice::<f64>().unwrap().iter().all(|&x| x == 0.0));
+}
+
+#[test]
+fn div_scalar_inplace_integer_zero_returns_error() {
+    let mut buf = Buffer::from_slice(&[2_i32, 4, 6]).unwrap();
+    let err = ops::div_scalar_inplace(&mut buf, 0_i32).unwrap_err();
+    assert!(matches!(err, MohuError::DivisionByZero));
+    assert_eq!(buf.as_slice::<i32>().unwrap(), &[2, 4, 6]);
 }
 
 #[test]


### PR DESCRIPTION
## What

Fixes #202.

I hit this while checking the scalar division path in `mohu-buffer`: integer division by zero could panic inside `div_scalar_inplace` instead of returning the existing typed error.

This PR keeps the change narrow:
- checks integer scalar divisors before the parallel division closure runs
- returns `MohuError::DivisionByZero` for integer zero divisors
- adds a regression test that also verifies the buffer is left unchanged

## Why

Library callers should be able to handle invalid arithmetic through `MohuResult`. A panic here is hard to recover from and does not match the error-handling style used elsewhere in the workspace.

## How

The guard uses the compile-time scalar dtype and the repo's `bail!` helper:

```rust
if T::DTYPE.is_integer() && scalar == T::ZERO {
    bail!(MohuError::DivisionByZero);
}
```

Float division behavior is left untouched.

## Verification

Passed:

```sh
cargo test -p mohu-buffer div_scalar_inplace_integer_zero_returns_error --all-features
cargo check -p mohu-buffer --all-features
git diff --check -- crates/mohu-buffer/src/ops.rs crates/mohu-buffer/tests/integration.rs
```

Known pre-existing repo failures while checking locally:

```sh
cargo clippy -p mohu-buffer --all-targets --all-features -- -D warnings
```

This currently fails before reaching this change because of existing `mohu-dtype` clippy warnings in `macros.rs`, `dtype.rs`, `finfo.rs`, and `iinfo.rs`.

```sh
cargo fmt -p mohu-buffer -- --check
```

This also reports broad pre-existing rustfmt drift across `mohu-buffer` files and examples. I did not reformat unrelated files in this PR.

Working on this as part of GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detect division-by-zero for integer buffers and return an error instead of performing the operation, preventing invalid changes.

* **Tests**
  * Added an integration test confirming zero-division on integer buffers is rejected and buffer contents remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
