### PR TITLE
docs: add CHANGELOG.md in Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-01-01
+## [0.1.0] - 2026-03-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
+
+## [0.1.0] - 2026-01-01
+
+### Added
+
+#### Foundation Layer
+- `mohu-error`: error types, error codes, and diagnostic reporter
+- `mohu-dtype`: `DType` enum, scalar traits, and type-promotion rules
+- `mohu-buffer`: aligned allocation, memory layout, strides, and DLPack v0.8 import/export
+- `mohu-array`: N-dimensional array type built on `mohu-buffer`
+- `mohu-core`: re-export facade unifying the four foundation crates
+
+#### Dispatch & Protocol Layer
+- `mohu-simd`: AVX2, AVX-512, and NEON SIMD kernel primitives
+- `mohu-ufunc`: universal-function protocol supporting broadcast, reduce, and outer operations
+- `mohu-index`: advanced indexing — fancy indexing, boolean masks, and take/put
+
+#### Compute Layer
+- `mohu-ops`: element-wise operations, matrix multiplication, and reductions
+- `mohu-fft`: FFT, IFFT, RFFT, and 2-D FFT via `rustfft`
+- `mohu-random`: PRNG engines (PCG64, Philox) and statistical distributions
+- `mohu-special`: special math functions — erf, gamma, beta, Bessel, and more
+- `mohu-stats`: descriptive statistics and hypothesis tests
+
+#### Data Structure Extensions
+- `mohu-sparse`: COO, CSR, and CSC sparse matrix formats
+- `mohu-masked`: masked arrays with null/invalid value propagation
+
+#### I/O & Interop
+- `mohu-io`: read/write support for .npy, .npz, CSV, HDF5, and Parquet formats
+
+#### Developer Tooling
+- `mohu-testing`: test fixtures, property-based tests, and array comparison utilities
+
+#### Infrastructure
+- GitHub Actions CI pipeline: `fmt`, `clippy`, build, test, MSRV, `cargo-deny`, coverage, and fuzz-build jobs
+- Automated PR review bot, DCO sign-off enforcement, PR title validation, and CodeRabbit integration
+- Workspace-level build profiles: `release`, `dist-release` (fat LTO), and `bench`


### PR DESCRIPTION
Closes #60

## What
Add `CHANGELOG.md` at the workspace root following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.

## Why
`CONTRIBUTING.md` PR checklist requires updating `CHANGELOG.md`, but the file only had a bare `[Unreleased]` header with no content and no `[0.1.0]` section, making the checklist item impossible to fulfill.

## How
- Kept the existing `[Unreleased]` section empty and ready for future entries
- Added a `[0.1.0]` section populated by reading `Cargo.toml` and each crate's documented purpose, grouped by layer: Foundation, Dispatch & Protocol, Compute, Data Structures, I/O, and Infrastructure

## Checklist
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all` applied
- [x] `CHANGELOG.md` updated (if user-facing change)
- [ ] Benchmarks added or updated (if performance-sensitive path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with a new 0.1.0 release entry dated 2026-03-16, preserving the existing "Unreleased" header.
  * Added a structured "Added" section grouped into foundation, dispatch/protocol, compute, data-structure extensions, I/O & interop, developer tooling, and infrastructure/CI/workspace build profiles.
  * Minor formatting and summary clarifications for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->