### PR TITLE
Add comprehensive tests for where_select

### DIFF
--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -14,15 +14,12 @@ use rayon::prelude::*;
 use mohu_dtype::{
     cast::cast_scalar_unchecked,
     dispatch_dtype,
-    promote::{can_cast, CastMode},
+    promote::{CastMode, can_cast},
     scalar::Scalar,
 };
 use mohu_error::{MohuError, MohuResult};
 
-use crate::{
-    buffer::Buffer,
-    strides::StridedByteIter,
-};
+use crate::{buffer::Buffer, strides::StridedByteIter};
 
 // ─── fill_raw ────────────────────────────────────────────────────────────────
 
@@ -37,7 +34,8 @@ pub fn fill_raw(buf: &mut Buffer, fill_bytes: &[u8]) -> MohuResult<()> {
     if fill_bytes.len() != itemsize {
         return Err(MohuError::bug(format!(
             "fill_raw: fill_bytes.len()={} != itemsize={}",
-            fill_bytes.len(), itemsize
+            fill_bytes.len(),
+            itemsize
         )));
     }
     if !buf.is_writeable() {
@@ -48,9 +46,7 @@ pub fn fill_raw(buf: &mut Buffer, fill_bytes: &[u8]) -> MohuResult<()> {
     if buf.is_c_contiguous() {
         let total = buf.len() * itemsize;
         // SAFETY: buf is uniquely owned, C-contiguous, pointer is valid.
-        let slice = unsafe {
-            std::slice::from_raw_parts_mut(buf.as_mut_ptr(), total)
-        };
+        let slice = unsafe { std::slice::from_raw_parts_mut(buf.as_mut_ptr(), total) };
         // Parallel fill: split into 4KiB chunks and fill each on Rayon threads.
         let chunk_size = 4096.max(itemsize * 64);
         slice.par_chunks_mut(chunk_size).for_each(|chunk| {
@@ -66,11 +62,7 @@ pub fn fill_raw(buf: &mut Buffer, fill_bytes: &[u8]) -> MohuResult<()> {
         for off in StridedByteIter::new(buf.shape(), buf.strides(), buf.offset()) {
             // SAFETY: stride iterator yields valid byte offsets within the buffer.
             unsafe {
-                std::ptr::copy_nonoverlapping(
-                    fill_bytes.as_ptr(),
-                    raw_ptr.add(off),
-                    itemsize,
-                );
+                std::ptr::copy_nonoverlapping(fill_bytes.as_ptr(), raw_ptr.add(off), itemsize);
             }
         }
     }
@@ -89,7 +81,7 @@ where
     if T::DTYPE != buf.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: T::DTYPE.to_string(),
-            got:      buf.dtype().to_string(),
+            got: buf.dtype().to_string(),
         });
     }
     if !buf.is_writeable() {
@@ -140,9 +132,7 @@ pub fn fill_zero(buf: &mut Buffer) -> MohuResult<()> {
 /// Dispatches at runtime over all 15 dtypes.
 pub fn fill_one(buf: &mut Buffer) -> MohuResult<()> {
     macro_rules! do_fill_one {
-        ($T:ty) => {{
-            fill(buf, <$T as Scalar>::ONE)
-        }};
+        ($T:ty) => {{ fill(buf, <$T as Scalar>::ONE) }};
     }
     dispatch_dtype!(buf.dtype(), do_fill_one)
 }
@@ -157,13 +147,13 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
     if src.dtype() != dst.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: src.dtype().to_string(),
-            got:      dst.dtype().to_string(),
+            got: dst.dtype().to_string(),
         });
     }
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
             expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            got: dst.shape().to_vec(),
         });
     }
     if !dst.is_writeable() {
@@ -176,7 +166,7 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
     if src.is_c_contiguous() && dst.is_c_contiguous() {
         // Parallel memcpy: split into cache-friendly 64 KiB chunks.
         let src_bytes = src.len() * itemsize;
-        let chunk     = 65536_usize.max(itemsize);
+        let chunk = 65536_usize.max(itemsize);
         unsafe {
             let s = std::slice::from_raw_parts(src.as_ptr(), src_bytes);
             let d = std::slice::from_raw_parts_mut(dst.as_mut_ptr(), src_bytes);
@@ -190,16 +180,12 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
         let dst_raw = unsafe { dst.as_mut_ptr() };
         let dst_itemsize = dst.itemsize();
 
-        for (elem_idx, src_off) in StridedByteIter::new(
-            src.shape(), src.strides(), src.offset(),
-        ).enumerate() {
+        for (elem_idx, src_off) in
+            StridedByteIter::new(src.shape(), src.strides(), src.offset()).enumerate()
+        {
             let dst_off = elem_idx * dst_itemsize;
             unsafe {
-                std::ptr::copy_nonoverlapping(
-                    src_raw.add(src_off),
-                    dst_raw.add(dst_off),
-                    itemsize,
-                );
+                std::ptr::copy_nonoverlapping(src_raw.add(src_off), dst_raw.add(dst_off), itemsize);
             }
         }
     }
@@ -217,7 +203,7 @@ pub fn cast_copy(src: &Buffer, dst: &mut Buffer, mode: CastMode) -> MohuResult<(
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
             expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            got: dst.shape().to_vec(),
         });
     }
     if src.dtype() == dst.dtype() {
@@ -225,8 +211,8 @@ pub fn cast_copy(src: &Buffer, dst: &mut Buffer, mode: CastMode) -> MohuResult<(
     }
     if !can_cast(src.dtype(), dst.dtype(), mode) {
         return Err(MohuError::InvalidCast {
-            from:   src.dtype().to_string(),
-            to:     dst.dtype().to_string(),
+            from: src.dtype().to_string(),
+            to: dst.dtype().to_string(),
             reason: format!("{mode:?} cast is not permitted"),
         });
     }
@@ -241,9 +227,7 @@ pub fn cast_copy(src: &Buffer, dst: &mut Buffer, mode: CastMode) -> MohuResult<(
     macro_rules! cast_src {
         ($S:ty) => {{
             macro_rules! cast_dst {
-                ($D:ty) => {{
-                    cast_typed::<$S, $D>(src, dst)
-                }};
+                ($D:ty) => {{ cast_typed::<$S, $D>(src, dst) }};
             }
             dispatch_dtype!(dst_dtype, cast_dst)
         }};
@@ -278,9 +262,9 @@ fn cast_typed<S: Scalar + Send + Sync, D: Scalar + Send + Sync>(
         let dst_raw = unsafe { dst.as_mut_ptr() };
         let dst_itemsize = D::ITEMSIZE;
 
-        for (elem_idx, src_off) in StridedByteIter::new(
-            src.shape(), src.strides(), src.offset(),
-        ).enumerate() {
+        for (elem_idx, src_off) in
+            StridedByteIter::new(src.shape(), src.strides(), src.offset()).enumerate()
+        {
             let dst_off = elem_idx * dst_itemsize;
             unsafe {
                 let s = (src_raw.add(src_off) as *const S).read_unaligned();
@@ -308,7 +292,7 @@ where
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
             expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            got: dst.shape().to_vec(),
         });
     }
     if !dst.is_writeable() {
@@ -359,12 +343,7 @@ where
 ///
 /// Computes `init` combined with every element using `combine`.
 /// Uses Rayon's `map_reduce` to parallelise across chunks.
-pub fn reduce<T, R, F, G>(
-    buf:     &Buffer,
-    init:    R,
-    map_fn:  F,
-    combine: G,
-) -> MohuResult<R>
+pub fn reduce<T, R, F, G>(buf: &Buffer, init: R, map_fn: F, combine: G) -> MohuResult<R>
 where
     T: Scalar + Send + Sync,
     R: Clone + Send + Sync,
@@ -374,7 +353,7 @@ where
     if T::DTYPE != buf.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: T::DTYPE.to_string(),
-            got:      buf.dtype().to_string(),
+            got: buf.dtype().to_string(),
         });
     }
     if !buf.is_c_contiguous() {
@@ -403,7 +382,7 @@ where
     if T::DTYPE != buf.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: T::DTYPE.to_string(),
-            got:      buf.dtype().to_string(),
+            got: buf.dtype().to_string(),
         });
     }
     if !buf.is_writeable() {
@@ -419,7 +398,9 @@ where
         slice.par_iter_mut().enumerate().for_each(|(i, v)| {
             // start + step * i  — computed without shared mutable state
             let mut acc = start;
-            for _ in 0..i { acc = acc + step; } // naive but correct; compiler may vectorise
+            for _ in 0..i {
+                acc = acc + step;
+            } // naive but correct; compiler may vectorise
             *v = acc;
         });
     } else {
@@ -427,7 +408,9 @@ where
         let raw_ptr = unsafe { buf.as_mut_ptr() };
         for (i, off) in StridedByteIter::new(buf.shape(), buf.strides(), buf.offset()).enumerate() {
             let mut acc = start;
-            for _ in 0..i { acc = acc + step; }
+            for _ in 0..i {
+                acc = acc + step;
+            }
             unsafe {
                 (raw_ptr.add(off) as *mut T).write_unaligned(acc);
             }
@@ -450,12 +433,7 @@ where
 /// 3. **Up-sweep**: each chunk adds its carry offset in parallel.
 ///
 /// This achieves O(n) work and O(log n) span, identical to serial complexity.
-pub fn parallel_scan<T, F>(
-    src:      &Buffer,
-    dst:      &mut Buffer,
-    identity: T,
-    f:        F,
-) -> MohuResult<()>
+pub fn parallel_scan<T, F>(src: &Buffer, dst: &mut Buffer, identity: T, f: F) -> MohuResult<()>
 where
     T: Scalar + Copy + Send + Sync,
     F: Fn(T, T) -> T + Send + Sync + Copy,
@@ -463,13 +441,13 @@ where
     if T::DTYPE != src.dtype() || T::DTYPE != dst.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: T::DTYPE.to_string(),
-            got:      src.dtype().to_string(),
+            got: src.dtype().to_string(),
         });
     }
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
             expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            got: dst.shape().to_vec(),
         });
     }
     if !src.is_c_contiguous() || !dst.is_c_contiguous() {
@@ -480,14 +458,14 @@ where
     }
     dst.make_unique()?;
 
-    let len    = src.len();
-    let src_s  = unsafe { std::slice::from_raw_parts(src.as_ptr() as *const T, len) };
-    let dst_s  = unsafe { std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut T, len) };
+    let len = src.len();
+    let src_s = unsafe { std::slice::from_raw_parts(src.as_ptr() as *const T, len) };
+    let dst_s = unsafe { std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut T, len) };
 
     // Chunk size: balance parallelism vs. carry overhead.
-    let n_threads  = rayon::current_num_threads().max(1);
+    let n_threads = rayon::current_num_threads().max(1);
     let chunk_size = (len / n_threads).max(256).next_power_of_two();
-    let n_chunks   = len.div_ceil(chunk_size);
+    let n_chunks = len.div_ceil(chunk_size);
 
     // Step 1: local scans + collect chunk totals.
     let mut chunk_totals: Vec<T> = vec![identity; n_chunks];
@@ -535,29 +513,29 @@ where
 /// All four buffers must be C-contiguous.
 pub fn where_select<T: Scalar + Copy + Send + Sync>(
     mask: &Buffer,
-    a:    &Buffer,
-    b:    &Buffer,
-    dst:  &mut Buffer,
+    a: &Buffer,
+    b: &Buffer,
+    dst: &mut Buffer,
 ) -> MohuResult<()> {
     use mohu_dtype::DType;
 
     if mask.dtype() != DType::U8 {
         return Err(MohuError::DTypeMismatch {
             expected: "U8".to_string(),
-            got:      mask.dtype().to_string(),
+            got: mask.dtype().to_string(),
         });
     }
     for (name, buf) in [("a", a), ("b", b)] {
         if T::DTYPE != buf.dtype() {
             return Err(MohuError::DTypeMismatch {
                 expected: T::DTYPE.to_string(),
-                got:      buf.dtype().to_string(),
+                got: buf.dtype().to_string(),
             });
         }
         if buf.shape() != mask.shape() {
             return Err(MohuError::ShapeMismatch {
                 expected: mask.shape().to_vec(),
-                got:      buf.shape().to_vec(),
+                got: buf.shape().to_vec(),
             });
         }
         if !buf.is_c_contiguous() {
@@ -565,20 +543,25 @@ pub fn where_select<T: Scalar + Copy + Send + Sync>(
             return Err(MohuError::NonContiguous);
         }
     }
-    if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
+    if !dst.is_writeable() {
+        return Err(MohuError::ReadOnly);
+    }
     if dst.shape() != mask.shape() {
         return Err(MohuError::ShapeMismatch {
             expected: mask.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            got: dst.shape().to_vec(),
         });
     }
     dst.make_unique()?;
 
-    let len    = mask.len();
-    let m_ptr  = mask.as_ptr();
-    let a_ptr  = a.as_ptr() as *const T;
-    let b_ptr  = b.as_ptr() as *const T;
-    let d_ptr  = unsafe { dst.as_mut_ptr() } as *mut T;
+    let len = mask.len();
+    if len == 0 {
+        return Ok(());
+    }
+    let m_ptr = mask.as_ptr();
+    let a_ptr = a.as_ptr() as *const T;
+    let b_ptr = b.as_ptr() as *const T;
+    let d_ptr = unsafe { dst.as_mut_ptr() } as *mut T;
 
     let m_s = unsafe { std::slice::from_raw_parts(m_ptr, len) };
     let a_s = unsafe { std::slice::from_raw_parts(a_ptr, len) };
@@ -608,29 +591,37 @@ where
     if T::DTYPE != src.dtype() || T::DTYPE != dst.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: T::DTYPE.to_string(),
-            got:      src.dtype().to_string(),
+            got: src.dtype().to_string(),
         });
     }
     if src.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
             expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            got: dst.shape().to_vec(),
         });
     }
     if !src.is_c_contiguous() || !dst.is_c_contiguous() {
         return Err(MohuError::NonContiguous);
     }
-    if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
+    if !dst.is_writeable() {
+        return Err(MohuError::ReadOnly);
+    }
     dst.make_unique()?;
 
-    let len   = src.len();
+    let len = src.len();
     let s_ptr = src.as_ptr() as *const T;
     let d_ptr = unsafe { dst.as_mut_ptr() } as *mut T;
-    let s_s   = unsafe { std::slice::from_raw_parts(s_ptr, len) };
-    let d_s   = unsafe { std::slice::from_raw_parts_mut(d_ptr, len) };
+    let s_s = unsafe { std::slice::from_raw_parts(s_ptr, len) };
+    let d_s = unsafe { std::slice::from_raw_parts_mut(d_ptr, len) };
 
     s_s.par_iter().zip(d_s.par_iter_mut()).for_each(|(s, d)| {
-        *d = if *s < lo { lo } else if *s > hi { hi } else { *s };
+        *d = if *s < lo {
+            lo
+        } else if *s > hi {
+            hi
+        } else {
+            *s
+        };
     });
 
     Ok(())
@@ -648,13 +639,13 @@ pub fn gather(src: &Buffer, indices: &Buffer, dst: &mut Buffer) -> MohuResult<()
     if indices.dtype() != DType::I64 {
         return Err(MohuError::DTypeMismatch {
             expected: "I64".to_string(),
-            got:      indices.dtype().to_string(),
+            got: indices.dtype().to_string(),
         });
     }
     if src.dtype() != dst.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: src.dtype().to_string(),
-            got:      dst.dtype().to_string(),
+            got: dst.dtype().to_string(),
         });
     }
     if !src.is_c_contiguous() || !indices.is_c_contiguous() || !dst.is_c_contiguous() {
@@ -663,39 +654,43 @@ pub fn gather(src: &Buffer, indices: &Buffer, dst: &mut Buffer) -> MohuResult<()
     if indices.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
             expected: indices.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            got: dst.shape().to_vec(),
         });
     }
-    if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
+    if !dst.is_writeable() {
+        return Err(MohuError::ReadOnly);
+    }
     dst.make_unique()?;
 
-    let itemsize  = src.dtype().itemsize();
-    let src_len   = src.len();
-    let n_idx     = indices.len();
+    let itemsize = src.dtype().itemsize();
+    let src_len = src.len();
+    let n_idx = indices.len();
 
     // Build typed slices from the raw pointers.  All three buffers are
     // exclusively borrowed (src immutably, dst mutably) for this call.
     // Using &[u8] for src makes it Sync, enabling safe sharing across Rayon threads.
-    let src_bytes: &[u8] = unsafe {
-        std::slice::from_raw_parts(src.as_ptr(), src_len * itemsize)
-    };
-    let idx_s: &[i64] = unsafe {
-        std::slice::from_raw_parts(indices.as_ptr() as *const i64, n_idx)
-    };
-    let dst_b: &mut [u8] = unsafe {
-        std::slice::from_raw_parts_mut(dst.as_mut_ptr(), n_idx * itemsize)
-    };
+    let src_bytes: &[u8] = unsafe { std::slice::from_raw_parts(src.as_ptr(), src_len * itemsize) };
+    let idx_s: &[i64] =
+        unsafe { std::slice::from_raw_parts(indices.as_ptr() as *const i64, n_idx) };
+    let dst_b: &mut [u8] =
+        unsafe { std::slice::from_raw_parts_mut(dst.as_mut_ptr(), n_idx * itemsize) };
 
-    idx_s.par_iter().zip(dst_b.par_chunks_mut(itemsize)).for_each(|(&idx, out)| {
-        let i = if idx < 0 {
-            (src_len as i64 + idx) as usize
-        } else {
-            idx as usize
-        };
-        debug_assert!(i < src_len, "gather: index {i} out of bounds (len {src_len})");
-        let i = i.min(src_len.saturating_sub(1)); // clamp in release
-        out.copy_from_slice(&src_bytes[i * itemsize..(i + 1) * itemsize]);
-    });
+    idx_s
+        .par_iter()
+        .zip(dst_b.par_chunks_mut(itemsize))
+        .for_each(|(&idx, out)| {
+            let i = if idx < 0 {
+                (src_len as i64 + idx) as usize
+            } else {
+                idx as usize
+            };
+            debug_assert!(
+                i < src_len,
+                "gather: index {i} out of bounds (len {src_len})"
+            );
+            let i = i.min(src_len.saturating_sub(1)); // clamp in release
+            out.copy_from_slice(&src_bytes[i * itemsize..(i + 1) * itemsize]);
+        });
 
     Ok(())
 }
@@ -715,13 +710,13 @@ pub fn scatter(dst: &mut Buffer, indices: &Buffer, src: &Buffer) -> MohuResult<(
     if indices.dtype() != DType::I64 {
         return Err(MohuError::DTypeMismatch {
             expected: "I64".to_string(),
-            got:      indices.dtype().to_string(),
+            got: indices.dtype().to_string(),
         });
     }
     if src.dtype() != dst.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: src.dtype().to_string(),
-            got:      dst.dtype().to_string(),
+            got: dst.dtype().to_string(),
         });
     }
     if !src.is_c_contiguous() || !indices.is_c_contiguous() || !dst.is_c_contiguous() {
@@ -730,18 +725,20 @@ pub fn scatter(dst: &mut Buffer, indices: &Buffer, src: &Buffer) -> MohuResult<(
     if indices.len() != src.len() {
         return Err(MohuError::ShapeMismatch {
             expected: indices.shape().to_vec(),
-            got:      src.shape().to_vec(),
+            got: src.shape().to_vec(),
         });
     }
-    if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
+    if !dst.is_writeable() {
+        return Err(MohuError::ReadOnly);
+    }
     dst.make_unique()?;
 
-    let itemsize  = src.dtype().itemsize();
-    let dst_len   = dst.len();
-    let n_src     = src.len();
-    let idx_ptr   = indices.as_ptr() as *const i64;
-    let src_ptr   = src.as_ptr();
-    let dst_ptr   = unsafe { dst.as_mut_ptr() };
+    let itemsize = src.dtype().itemsize();
+    let dst_len = dst.len();
+    let n_src = src.len();
+    let idx_ptr = indices.as_ptr() as *const i64;
+    let src_ptr = src.as_ptr();
+    let dst_ptr = unsafe { dst.as_mut_ptr() };
 
     let idx_s = unsafe { std::slice::from_raw_parts(idx_ptr, n_src) };
     let src_b = unsafe { std::slice::from_raw_parts(src_ptr, n_src * itemsize) };
@@ -826,18 +823,20 @@ pub fn abs_copy(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
     }
     match src.dtype() {
         // Unsigned and bool: abs is the identity.
-        DType::Bool | DType::U8 | DType::U16 | DType::U32 | DType::U64 => copy_to_contiguous(src, dst),
+        DType::Bool | DType::U8 | DType::U16 | DType::U32 | DType::U64 => {
+            copy_to_contiguous(src, dst)
+        },
         // Signed integers and reals: round-trip through f64.
-        DType::I8   => abs_via_f64!(i8),
-        DType::I16  => abs_via_f64!(i16),
-        DType::I32  => abs_via_f64!(i32),
-        DType::I64  => abs_via_f64!(i64),
-        DType::F16  => abs_via_f64!(::half::f16),
+        DType::I8 => abs_via_f64!(i8),
+        DType::I16 => abs_via_f64!(i16),
+        DType::I32 => abs_via_f64!(i32),
+        DType::I64 => abs_via_f64!(i64),
+        DType::F16 => abs_via_f64!(::half::f16),
         DType::BF16 => abs_via_f64!(::half::bf16),
-        DType::F32  => parallel_map::<f32, f32, _>(src, dst, |x| x.abs()),
-        DType::F64  => parallel_map::<f64, f64, _>(src, dst, |x| x.abs()),
+        DType::F32 => parallel_map::<f32, f32, _>(src, dst, |x| x.abs()),
+        DType::F64 => parallel_map::<f64, f64, _>(src, dst, |x| x.abs()),
         // Complex: abs each component independently (preserves dtype).
-        DType::C64  => parallel_map::<Complex<f32>, Complex<f32>, _>(src, dst, |x| {
+        DType::C64 => parallel_map::<Complex<f32>, Complex<f32>, _>(src, dst, |x| {
             Complex::new(x.re.abs(), x.im.abs())
         }),
         DType::C128 => parallel_map::<Complex<f64>, Complex<f64>, _>(src, dst, |x| {
@@ -868,27 +867,23 @@ pub fn neg_copy(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
     match src.dtype() {
         // Bool has no meaningful negation; produce a copy.
         DType::Bool => copy_to_contiguous(src, dst),
-        DType::I8   => neg_via_i128!(i8),
-        DType::I16  => neg_via_i128!(i16),
-        DType::I32  => neg_via_i128!(i32),
-        DType::I64  => neg_via_i128!(i64),
-        DType::U8   => parallel_map::<u8,  u8,  _>(src, dst, |x| x.wrapping_neg()),
-        DType::U16  => parallel_map::<u16, u16, _>(src, dst, |x| x.wrapping_neg()),
-        DType::U32  => parallel_map::<u32, u32, _>(src, dst, |x| x.wrapping_neg()),
-        DType::U64  => parallel_map::<u64, u64, _>(src, dst, |x| x.wrapping_neg()),
-        DType::F16  => {
-            parallel_map::<::half::f16, ::half::f16, _>(src, dst, |x| {
-                ::half::f16::from_f32(-x.to_f32())
-            })
-        }
-        DType::BF16 => {
-            parallel_map::<::half::bf16, ::half::bf16, _>(src, dst, |x| {
-                ::half::bf16::from_f32(-x.to_f32())
-            })
-        }
-        DType::F32  => parallel_map::<f32, f32, _>(src, dst, |x| -x),
-        DType::F64  => parallel_map::<f64, f64, _>(src, dst, |x| -x),
-        DType::C64  => parallel_map::<Complex<f32>, Complex<f32>, _>(src, dst, |x| -x),
+        DType::I8 => neg_via_i128!(i8),
+        DType::I16 => neg_via_i128!(i16),
+        DType::I32 => neg_via_i128!(i32),
+        DType::I64 => neg_via_i128!(i64),
+        DType::U8 => parallel_map::<u8, u8, _>(src, dst, |x| x.wrapping_neg()),
+        DType::U16 => parallel_map::<u16, u16, _>(src, dst, |x| x.wrapping_neg()),
+        DType::U32 => parallel_map::<u32, u32, _>(src, dst, |x| x.wrapping_neg()),
+        DType::U64 => parallel_map::<u64, u64, _>(src, dst, |x| x.wrapping_neg()),
+        DType::F16 => parallel_map::<::half::f16, ::half::f16, _>(src, dst, |x| {
+            ::half::f16::from_f32(-x.to_f32())
+        }),
+        DType::BF16 => parallel_map::<::half::bf16, ::half::bf16, _>(src, dst, |x| {
+            ::half::bf16::from_f32(-x.to_f32())
+        }),
+        DType::F32 => parallel_map::<f32, f32, _>(src, dst, |x| -x),
+        DType::F64 => parallel_map::<f64, f64, _>(src, dst, |x| -x),
+        DType::C64 => parallel_map::<Complex<f32>, Complex<f32>, _>(src, dst, |x| -x),
         DType::C128 => parallel_map::<Complex<f64>, Complex<f64>, _>(src, dst, |x| -x),
     }
 }
@@ -903,7 +898,7 @@ pub fn sqrt_copy(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
         DType::F64 => parallel_map::<f64, f64, _>(src, dst, |x| x.sqrt()),
         other => Err(MohuError::DTypeMismatch {
             expected: "F32 or F64".to_string(),
-            got:      other.to_string(),
+            got: other.to_string(),
         }),
     }
 }
@@ -916,7 +911,7 @@ pub fn ln_copy(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
         DType::F64 => parallel_map::<f64, f64, _>(src, dst, |x| x.ln()),
         other => Err(MohuError::DTypeMismatch {
             expected: "F32 or F64".to_string(),
-            got:      other.to_string(),
+            got: other.to_string(),
         }),
     }
 }
@@ -929,7 +924,7 @@ pub fn exp_copy(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
         DType::F64 => parallel_map::<f64, f64, _>(src, dst, |x| x.exp()),
         other => Err(MohuError::DTypeMismatch {
             expected: "F32 or F64".to_string(),
-            got:      other.to_string(),
+            got: other.to_string(),
         }),
     }
 }
@@ -944,48 +939,49 @@ pub fn flip_axis_copy(src: &Buffer, dst: &mut Buffer, axis: usize) -> MohuResult
     if src.dtype() != dst.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: src.dtype().to_string(),
-            got:      dst.dtype().to_string(),
+            got: dst.dtype().to_string(),
         });
     }
     if src.shape() != dst.shape() {
         return Err(MohuError::ShapeMismatch {
             expected: src.shape().to_vec(),
-            got:      dst.shape().to_vec(),
+            got: dst.shape().to_vec(),
         });
     }
     if axis >= src.ndim() {
         return Err(MohuError::bug(format!(
-            "flip_axis_copy: axis {axis} out of bounds for ndim {}", src.ndim()
+            "flip_axis_copy: axis {axis} out of bounds for ndim {}",
+            src.ndim()
         )));
     }
     if !dst.is_c_contiguous() {
         return Err(MohuError::NonContiguous);
     }
-    if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
+    if !dst.is_writeable() {
+        return Err(MohuError::ReadOnly);
+    }
     dst.make_unique()?;
 
     let itemsize = src.dtype().itemsize();
-    let src_raw  = src.as_ptr();
-    let dst_raw  = unsafe { dst.as_mut_ptr() };
+    let src_raw = src.as_ptr();
+    let dst_raw = unsafe { dst.as_mut_ptr() };
 
     use crate::strides::NdIndexIter;
 
     // Walk destination in C order; compute the flipped source index.
     for (dst_flat, mut idx) in NdIndexIter::new(dst.shape()).enumerate() {
         // Flip the requested axis.
-        let dim   = src.shape()[axis];
+        let dim = src.shape()[axis];
         idx[axis] = dim - 1 - idx[axis];
 
-        let src_off = src.layout().byte_offset(idx.as_slice())
+        let src_off = src
+            .layout()
+            .byte_offset(idx.as_slice())
             .expect("NdIndexIter always in bounds");
         let dst_off = dst_flat * itemsize;
 
         unsafe {
-            std::ptr::copy_nonoverlapping(
-                src_raw.add(src_off),
-                dst_raw.add(dst_off),
-                itemsize,
-            );
+            std::ptr::copy_nonoverlapping(src_raw.add(src_off), dst_raw.add(dst_off), itemsize);
         }
     }
 
@@ -1021,38 +1017,36 @@ pub fn sum_all_f64(buf: &Buffer) -> MohuResult<f64> {
     macro_rules! do_sum {
         ($T:ty) => {{
             if buf.is_c_contiguous() {
-                let s = unsafe {
-                    std::slice::from_raw_parts(buf.as_ptr() as *const $T, buf.len())
-                };
-                let sum: f64 = s.par_iter().map(|&x| {
-                    num_traits::cast::<$T, f64>(x).unwrap_or(0.0)
-                }).sum();
+                let s = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const $T, buf.len()) };
+                let sum: f64 = s
+                    .par_iter()
+                    .map(|&x| num_traits::cast::<$T, f64>(x).unwrap_or(0.0))
+                    .sum();
                 Ok(sum)
             } else {
                 let c = buf.to_contiguous()?;
-                let s = unsafe {
-                    std::slice::from_raw_parts(c.as_ptr() as *const $T, c.len())
-                };
-                let sum: f64 = s.par_iter().map(|&x| {
-                    num_traits::cast::<$T, f64>(x).unwrap_or(0.0)
-                }).sum();
+                let s = unsafe { std::slice::from_raw_parts(c.as_ptr() as *const $T, c.len()) };
+                let sum: f64 = s
+                    .par_iter()
+                    .map(|&x| num_traits::cast::<$T, f64>(x).unwrap_or(0.0))
+                    .sum();
                 Ok(sum)
             }
         }};
     }
     match buf.dtype() {
-        DType::I8   => do_sum!(i8),
-        DType::I16  => do_sum!(i16),
-        DType::I32  => do_sum!(i32),
-        DType::I64  => do_sum!(i64),
-        DType::U8   => do_sum!(u8),
-        DType::U16  => do_sum!(u16),
-        DType::U32  => do_sum!(u32),
-        DType::U64  => do_sum!(u64),
-        DType::F16  => do_sum!(::half::f16),
+        DType::I8 => do_sum!(i8),
+        DType::I16 => do_sum!(i16),
+        DType::I32 => do_sum!(i32),
+        DType::I64 => do_sum!(i64),
+        DType::U8 => do_sum!(u8),
+        DType::U16 => do_sum!(u16),
+        DType::U32 => do_sum!(u32),
+        DType::U64 => do_sum!(u64),
+        DType::F16 => do_sum!(::half::f16),
         DType::BF16 => do_sum!(::half::bf16),
-        DType::F32  => do_sum!(f32),
-        DType::F64  => do_sum!(f64),
+        DType::F32 => do_sum!(f32),
+        DType::F64 => do_sum!(f64),
         // Bool and C64/C128 handled above.
         _ => unreachable!(),
     }
@@ -1068,7 +1062,9 @@ pub fn min_all_f64(buf: &Buffer) -> MohuResult<f64> {
         });
     }
     if buf.dtype() == DType::Bool {
-        if buf.is_empty() { return Ok(f64::INFINITY); }
+        if buf.is_empty() {
+            return Ok(f64::INFINITY);
+        }
         let c;
         let s: &[u8] = if buf.is_c_contiguous() {
             unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) }
@@ -1090,28 +1086,30 @@ pub fn min_all_f64(buf: &Buffer) -> MohuResult<f64> {
                 c = buf.to_contiguous()?;
                 unsafe { std::slice::from_raw_parts(c.as_ptr() as *const $T, c.len()) }
             };
-            let m = s.par_iter().cloned().reduce_with(|a, b| {
-                match a.partial_cmp(&b) {
+            let m = s
+                .par_iter()
+                .cloned()
+                .reduce_with(|a, b| match a.partial_cmp(&b) {
                     Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => a,
                     _ => b,
-                }
-            }).unwrap_or(s[0]);
+                })
+                .unwrap_or(s[0]);
             Ok(num_traits::cast::<$T, f64>(m).unwrap_or(f64::NAN))
         }};
     }
     match buf.dtype() {
-        DType::I8   => do_min!(i8),
-        DType::I16  => do_min!(i16),
-        DType::I32  => do_min!(i32),
-        DType::I64  => do_min!(i64),
-        DType::U8   => do_min!(u8),
-        DType::U16  => do_min!(u16),
-        DType::U32  => do_min!(u32),
-        DType::U64  => do_min!(u64),
-        DType::F16  => do_min!(::half::f16),
+        DType::I8 => do_min!(i8),
+        DType::I16 => do_min!(i16),
+        DType::I32 => do_min!(i32),
+        DType::I64 => do_min!(i64),
+        DType::U8 => do_min!(u8),
+        DType::U16 => do_min!(u16),
+        DType::U32 => do_min!(u32),
+        DType::U64 => do_min!(u64),
+        DType::F16 => do_min!(::half::f16),
         DType::BF16 => do_min!(::half::bf16),
-        DType::F32  => do_min!(f32),
-        DType::F64  => do_min!(f64),
+        DType::F32 => do_min!(f32),
+        DType::F64 => do_min!(f64),
         _ => unreachable!(),
     }
 }
@@ -1126,7 +1124,9 @@ pub fn max_all_f64(buf: &Buffer) -> MohuResult<f64> {
         });
     }
     if buf.dtype() == DType::Bool {
-        if buf.is_empty() { return Ok(f64::NEG_INFINITY); }
+        if buf.is_empty() {
+            return Ok(f64::NEG_INFINITY);
+        }
         let c;
         let s: &[u8] = if buf.is_c_contiguous() {
             unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) }
@@ -1148,28 +1148,30 @@ pub fn max_all_f64(buf: &Buffer) -> MohuResult<f64> {
                 c = buf.to_contiguous()?;
                 unsafe { std::slice::from_raw_parts(c.as_ptr() as *const $T, c.len()) }
             };
-            let m = s.par_iter().cloned().reduce_with(|a, b| {
-                match a.partial_cmp(&b) {
+            let m = s
+                .par_iter()
+                .cloned()
+                .reduce_with(|a, b| match a.partial_cmp(&b) {
                     Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal) => a,
                     _ => b,
-                }
-            }).unwrap_or(s[0]);
+                })
+                .unwrap_or(s[0]);
             Ok(num_traits::cast::<$T, f64>(m).unwrap_or(f64::NAN))
         }};
     }
     match buf.dtype() {
-        DType::I8   => do_max!(i8),
-        DType::I16  => do_max!(i16),
-        DType::I32  => do_max!(i32),
-        DType::I64  => do_max!(i64),
-        DType::U8   => do_max!(u8),
-        DType::U16  => do_max!(u16),
-        DType::U32  => do_max!(u32),
-        DType::U64  => do_max!(u64),
-        DType::F16  => do_max!(::half::f16),
+        DType::I8 => do_max!(i8),
+        DType::I16 => do_max!(i16),
+        DType::I32 => do_max!(i32),
+        DType::I64 => do_max!(i64),
+        DType::U8 => do_max!(u8),
+        DType::U16 => do_max!(u16),
+        DType::U32 => do_max!(u32),
+        DType::U64 => do_max!(u64),
+        DType::F16 => do_max!(::half::f16),
         DType::BF16 => do_max!(::half::bf16),
-        DType::F32  => do_max!(f32),
-        DType::F64  => do_max!(f64),
+        DType::F32 => do_max!(f32),
+        DType::F64 => do_max!(f64),
         _ => unreachable!(),
     }
 }
@@ -1184,7 +1186,9 @@ pub fn argmin_flat(buf: &Buffer) -> MohuResult<usize> {
         });
     }
     if buf.dtype() == DType::Bool {
-        if buf.is_empty() { return Ok(0); }
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let c;
         let s: &[u8] = if buf.is_c_contiguous() {
             unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) }
@@ -1192,14 +1196,18 @@ pub fn argmin_flat(buf: &Buffer) -> MohuResult<usize> {
             c = buf.to_contiguous()?;
             unsafe { std::slice::from_raw_parts(c.as_ptr(), c.len()) }
         };
-        return Ok(s.iter().enumerate()
+        return Ok(s
+            .iter()
+            .enumerate()
             .min_by_key(|&(_, &v)| v)
             .map(|(i, _)| i)
             .unwrap_or(0));
     }
     macro_rules! do_argmin {
         ($T:ty) => {{
-            if buf.is_empty() { return Ok(0); }
+            if buf.is_empty() {
+                return Ok(0);
+            }
             let c;
             let s: &[$T] = if buf.is_c_contiguous() {
                 unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const $T, buf.len()) }
@@ -1207,27 +1215,30 @@ pub fn argmin_flat(buf: &Buffer) -> MohuResult<usize> {
                 c = buf.to_contiguous()?;
                 unsafe { std::slice::from_raw_parts(c.as_ptr() as *const $T, c.len()) }
             };
-            Ok(s.par_iter().enumerate()
-                .reduce_with(|(ai, av), (bi, bv)| {
-                    if av <= bv { (ai, av) } else { (bi, bv) }
-                })
+            Ok(s.par_iter()
+                .enumerate()
+                .reduce_with(
+                    |(ai, av), (bi, bv)| {
+                        if av <= bv { (ai, av) } else { (bi, bv) }
+                    },
+                )
                 .map(|(i, _)| i)
                 .unwrap_or(0))
         }};
     }
     match buf.dtype() {
-        DType::I8   => do_argmin!(i8),
-        DType::I16  => do_argmin!(i16),
-        DType::I32  => do_argmin!(i32),
-        DType::I64  => do_argmin!(i64),
-        DType::U8   => do_argmin!(u8),
-        DType::U16  => do_argmin!(u16),
-        DType::U32  => do_argmin!(u32),
-        DType::U64  => do_argmin!(u64),
-        DType::F16  => do_argmin!(::half::f16),
+        DType::I8 => do_argmin!(i8),
+        DType::I16 => do_argmin!(i16),
+        DType::I32 => do_argmin!(i32),
+        DType::I64 => do_argmin!(i64),
+        DType::U8 => do_argmin!(u8),
+        DType::U16 => do_argmin!(u16),
+        DType::U32 => do_argmin!(u32),
+        DType::U64 => do_argmin!(u64),
+        DType::F16 => do_argmin!(::half::f16),
         DType::BF16 => do_argmin!(::half::bf16),
-        DType::F32  => do_argmin!(f32),
-        DType::F64  => do_argmin!(f64),
+        DType::F32 => do_argmin!(f32),
+        DType::F64 => do_argmin!(f64),
         _ => unreachable!(),
     }
 }
@@ -1242,7 +1253,9 @@ pub fn argmax_flat(buf: &Buffer) -> MohuResult<usize> {
         });
     }
     if buf.dtype() == DType::Bool {
-        if buf.is_empty() { return Ok(0); }
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let c;
         let s: &[u8] = if buf.is_c_contiguous() {
             unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) }
@@ -1250,14 +1263,18 @@ pub fn argmax_flat(buf: &Buffer) -> MohuResult<usize> {
             c = buf.to_contiguous()?;
             unsafe { std::slice::from_raw_parts(c.as_ptr(), c.len()) }
         };
-        return Ok(s.iter().enumerate()
+        return Ok(s
+            .iter()
+            .enumerate()
             .max_by_key(|&(_, &v)| v)
             .map(|(i, _)| i)
             .unwrap_or(0));
     }
     macro_rules! do_argmax {
         ($T:ty) => {{
-            if buf.is_empty() { return Ok(0); }
+            if buf.is_empty() {
+                return Ok(0);
+            }
             let c;
             let s: &[$T] = if buf.is_c_contiguous() {
                 unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const $T, buf.len()) }
@@ -1265,27 +1282,30 @@ pub fn argmax_flat(buf: &Buffer) -> MohuResult<usize> {
                 c = buf.to_contiguous()?;
                 unsafe { std::slice::from_raw_parts(c.as_ptr() as *const $T, c.len()) }
             };
-            Ok(s.par_iter().enumerate()
-                .reduce_with(|(ai, av), (bi, bv)| {
-                    if av >= bv { (ai, av) } else { (bi, bv) }
-                })
+            Ok(s.par_iter()
+                .enumerate()
+                .reduce_with(
+                    |(ai, av), (bi, bv)| {
+                        if av >= bv { (ai, av) } else { (bi, bv) }
+                    },
+                )
                 .map(|(i, _)| i)
                 .unwrap_or(0))
         }};
     }
     match buf.dtype() {
-        DType::I8   => do_argmax!(i8),
-        DType::I16  => do_argmax!(i16),
-        DType::I32  => do_argmax!(i32),
-        DType::I64  => do_argmax!(i64),
-        DType::U8   => do_argmax!(u8),
-        DType::U16  => do_argmax!(u16),
-        DType::U32  => do_argmax!(u32),
-        DType::U64  => do_argmax!(u64),
-        DType::F16  => do_argmax!(::half::f16),
+        DType::I8 => do_argmax!(i8),
+        DType::I16 => do_argmax!(i16),
+        DType::I32 => do_argmax!(i32),
+        DType::I64 => do_argmax!(i64),
+        DType::U8 => do_argmax!(u8),
+        DType::U16 => do_argmax!(u16),
+        DType::U32 => do_argmax!(u32),
+        DType::U64 => do_argmax!(u64),
+        DType::F16 => do_argmax!(::half::f16),
         DType::BF16 => do_argmax!(::half::bf16),
-        DType::F32  => do_argmax!(f32),
-        DType::F64  => do_argmax!(f64),
+        DType::F32 => do_argmax!(f32),
+        DType::F64 => do_argmax!(f64),
         _ => unreachable!(),
     }
 }
@@ -1302,11 +1322,15 @@ pub fn fill_nontemporal_f32_buf(buf: &mut Buffer, value: f32) -> MohuResult<()> 
     if buf.dtype() != DType::F32 {
         return Err(MohuError::DTypeMismatch {
             expected: "F32".to_string(),
-            got:      buf.dtype().to_string(),
+            got: buf.dtype().to_string(),
         });
     }
-    if !buf.is_c_contiguous() { return Err(MohuError::NonContiguous); }
-    if !buf.is_writeable()    { return Err(MohuError::ReadOnly); }
+    if !buf.is_c_contiguous() {
+        return Err(MohuError::NonContiguous);
+    }
+    if !buf.is_writeable() {
+        return Err(MohuError::ReadOnly);
+    }
     buf.make_unique()?;
 
     let len = buf.len();
@@ -1316,15 +1340,17 @@ pub fn fill_nontemporal_f32_buf(buf: &mut Buffer, value: f32) -> MohuResult<()> 
     {
         // Fast path: non-temporal stores for aligned 32-byte regions.
         // Align the pointer upward to 32 bytes; fill the prefix with regular stores.
-        let addr      = ptr as usize;
+        let addr = ptr as usize;
         let align_off = (32 - addr % 32) % 32 / std::mem::size_of::<f32>();
-        let prefix    = align_off.min(len);
+        let prefix = align_off.min(len);
         for i in 0..prefix {
-            unsafe { ptr.add(i).write(value); }
+            unsafe {
+                ptr.add(i).write(value);
+            }
         }
-        let aligned_ptr  = unsafe { ptr.add(prefix) };
-        let aligned_len  = len - prefix;
-        let nt_len       = aligned_len / 8 * 8; // round down to multiple of 8
+        let aligned_ptr = unsafe { ptr.add(prefix) };
+        let aligned_len = len - prefix;
+        let nt_len = aligned_len / 8 * 8; // round down to multiple of 8
 
         if nt_len > 0 {
             // SAFETY: aligned_ptr is 32-byte aligned, nt_len is multiple of 8.
@@ -1339,7 +1365,9 @@ pub fn fill_nontemporal_f32_buf(buf: &mut Buffer, value: f32) -> MohuResult<()> 
         }
         // Scalar tail
         for i in (prefix + nt_len)..len {
-            unsafe { ptr.add(i).write(value); }
+            unsafe {
+                ptr.add(i).write(value);
+            }
         }
         return Ok(());
     }
@@ -1356,12 +1384,7 @@ pub fn fill_nontemporal_f32_buf(buf: &mut Buffer, value: f32) -> MohuResult<()> 
 
 /// Applies `f(a[i], b[i]) -> T` over all elements of two same-shape C-contiguous
 /// buffers, writing results into `dst`.  Generalises element-wise arithmetic.
-pub fn parallel_zip<S, D, F>(
-    a:   &Buffer,
-    b:   &Buffer,
-    dst: &mut Buffer,
-    f:   F,
-) -> MohuResult<()>
+pub fn parallel_zip<S, D, F>(a: &Buffer, b: &Buffer, dst: &mut Buffer, f: F) -> MohuResult<()>
 where
     S: Scalar + Copy + Send + Sync,
     D: Scalar + Copy + Send + Sync,
@@ -1370,26 +1393,28 @@ where
     if S::DTYPE != a.dtype() || S::DTYPE != b.dtype() {
         return Err(MohuError::DTypeMismatch {
             expected: S::DTYPE.to_string(),
-            got:      a.dtype().to_string(),
+            got: a.dtype().to_string(),
         });
     }
     if a.len() != b.len() || a.len() != dst.len() {
         return Err(MohuError::ShapeMismatch {
             expected: a.shape().to_vec(),
-            got:      b.shape().to_vec(),
+            got: b.shape().to_vec(),
         });
     }
     if !a.is_c_contiguous() || !b.is_c_contiguous() || !dst.is_c_contiguous() {
         return Err(MohuError::NonContiguous);
     }
-    if !dst.is_writeable() { return Err(MohuError::ReadOnly); }
+    if !dst.is_writeable() {
+        return Err(MohuError::ReadOnly);
+    }
     dst.make_unique()?;
 
-    let len   = a.len();
-    let a_s   = unsafe { std::slice::from_raw_parts(a.as_ptr() as *const S, len) };
-    let b_s   = unsafe { std::slice::from_raw_parts(b.as_ptr() as *const S, len) };
+    let len = a.len();
+    let a_s = unsafe { std::slice::from_raw_parts(a.as_ptr() as *const S, len) };
+    let b_s = unsafe { std::slice::from_raw_parts(b.as_ptr() as *const S, len) };
     let d_ptr = unsafe { dst.as_mut_ptr() } as *mut D;
-    let d_s   = unsafe { std::slice::from_raw_parts_mut(d_ptr, len) };
+    let d_s = unsafe { std::slice::from_raw_parts_mut(d_ptr, len) };
 
     a_s.par_iter()
         .zip(b_s.par_iter())

--- a/crates/mohu-buffer/tests/where_select.rs
+++ b/crates/mohu-buffer/tests/where_select.rs
@@ -1,0 +1,96 @@
+use mohu_buffer::{Buffer, Order, ops};
+use mohu_dtype::DType;
+
+#[test]
+fn where_select_all_true() {
+    let mask = Buffer::from_slice(&[1u8, 1, 1]).unwrap();
+
+    let a = Buffer::from_slice(&[1i32, 2, 3]).unwrap();
+    let b = Buffer::from_slice(&[4i32, 5, 6]).unwrap();
+
+    let mut dst = Buffer::alloc(DType::I32, &[3], Order::C).unwrap();
+
+    ops::where_select::<i32>(&mask, &a, &b, &mut dst).unwrap();
+
+    assert_eq!(dst.as_slice::<i32>().unwrap(), &[1, 2, 3]);
+}
+
+#[test]
+fn where_select_all_false() {
+    let mask = Buffer::from_slice(&[0u8, 0, 0]).unwrap();
+
+    let a = Buffer::from_slice(&[1i32, 2, 3]).unwrap();
+    let b = Buffer::from_slice(&[4i32, 5, 6]).unwrap();
+
+    let mut dst = Buffer::alloc(DType::I32, &[3], Order::C).unwrap();
+
+    ops::where_select::<i32>(&mask, &a, &b, &mut dst).unwrap();
+
+    assert_eq!(dst.as_slice::<i32>().unwrap(), &[4, 5, 6]);
+}
+
+#[test]
+fn where_select_alternating_mask() {
+    let mask = Buffer::from_slice(&[1u8, 0, 1, 0]).unwrap();
+
+    let a = Buffer::from_slice(&[1i32, 2, 3, 4]).unwrap();
+    let b = Buffer::from_slice(&[5i32, 6, 7, 8]).unwrap();
+
+    let mut dst = Buffer::alloc(DType::I32, &[4], Order::C).unwrap();
+
+    ops::where_select::<i32>(&mask, &a, &b, &mut dst).unwrap();
+
+    assert_eq!(dst.as_slice::<i32>().unwrap(), &[1, 6, 3, 8]);
+}
+
+#[test]
+fn where_select_shape_mismatch() {
+    let mask = Buffer::from_slice(&[1u8, 0, 1]).unwrap();
+
+    let a = Buffer::from_slice(&[1i32, 2, 3, 4]).unwrap();
+    let b = Buffer::from_slice(&[5i32, 6, 7, 8]).unwrap();
+
+    let mut dst = Buffer::alloc(DType::I32, &[4], Order::C).unwrap();
+
+    let result = ops::where_select::<i32>(&mask, &a, &b, &mut dst);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn where_select_empty_buffers() {
+    let mask = Buffer::from_slice::<u8>(&[]).unwrap();
+
+    let a = Buffer::from_slice::<i32>(&[]).unwrap();
+    let b = Buffer::from_slice::<i32>(&[]).unwrap();
+
+    let mut dst = Buffer::alloc(DType::I32, &[0], Order::C).unwrap();
+
+    ops::where_select::<i32>(&mask, &a, &b, &mut dst).unwrap();
+
+    assert_eq!(dst.len(), 0);
+}
+
+#[test]
+fn where_select_2d() {
+    let mask = Buffer::from_slice(&[1u8, 0, 0, 1])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+
+    let a = Buffer::from_slice(&[1i32, 2, 3, 4])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+
+    let b = Buffer::from_slice(&[5i32, 6, 7, 8])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+
+    let mut dst = Buffer::alloc(DType::I32, &[2, 2], Order::C).unwrap();
+
+    ops::where_select::<i32>(&mask, &a, &b, &mut dst).unwrap();
+
+    assert_eq!(dst.as_slice::<i32>().unwrap(), &[1, 6, 7, 4]);
+}


### PR DESCRIPTION
## What

Added comprehensive tests for `where_select` in `mohu-buffer`.

## Why

`where_select` is a core operation equivalent to NumPy's `np.where`, but it previously had no dedicated test coverage.

This PR adds coverage for:

* all-true masks
* all-false masks
* alternating masks
* shape mismatch handling
* empty buffers
* 2D selection

## How

Created a new integration test file:

* `crates/mohu-buffer/tests/where_select.rs`

Also fixed empty-buffer handling in `where_select` by returning early for zero-length buffers before unsafe slice creation.

Verified with:

`cargo test -p mohu-buffer --test where_select`

## Checklist

* [x] `cargo fmt --all` applied
* [ ] `cargo test --workspace` passes
* [ ] `cargo clippy --workspace -- -D warnings` passes
* [ ] `CHANGELOG.md` updated (not needed)
* [ ] Benchmarks added or updated (not needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied code formatting and normalization across buffer operations module.

* **Tests**
  * Added comprehensive test coverage for the `where_select` operation, including scenarios with all-true masks, all-false masks, alternating patterns, shape mismatches, empty buffers, and multi-dimensional tensors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->