### PR TITLE
fix(buffer): recover poisoned pool mutex

### DIFF
--- a/crates/mohu-buffer/src/pool.rs
+++ b/crates/mohu-buffer/src/pool.rs
@@ -483,28 +483,6 @@ impl BufferPool {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn stats_recovers_after_mutex_poison() {
-        let pool = BufferPool::new(1024);
-
-        std::thread::scope(|scope| {
-            let handle = scope.spawn(|| {
-                let _guard = pool.lock();
-                panic!("poison BufferPool lock");
-            });
-            assert!(handle.join().is_err());
-        });
-
-        let stats = pool.stats();
-        assert_eq!(stats.cached_bytes, 0);
-        assert_eq!(stats.cached_blocks, 0);
-    }
-}
-
 impl std::fmt::Debug for BufferPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let stats = self.stats();
@@ -531,3 +509,25 @@ impl std::fmt::Debug for BufferPool {
 /// ```
 pub static GLOBAL_POOL: std::sync::LazyLock<BufferPool> =
     std::sync::LazyLock::new(|| BufferPool::new(256 * 1024 * 1024));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stats_recovers_after_mutex_poison() {
+        let pool = BufferPool::new(1024);
+
+        std::thread::scope(|scope| {
+            let handle = scope.spawn(|| {
+                let _guard = pool.lock();
+                panic!("poison BufferPool lock");
+            });
+            assert!(handle.join().is_err());
+        });
+
+        let stats = pool.stats();
+        assert_eq!(stats.cached_bytes, 0);
+        assert_eq!(stats.cached_blocks, 0);
+    }
+}

--- a/crates/mohu-buffer/src/pool.rs
+++ b/crates/mohu-buffer/src/pool.rs
@@ -476,7 +476,32 @@ impl BufferPool {
     }
 
     fn lock(&self) -> MutexGuard<'_, PoolInner> {
-        self.inner.lock().expect("BufferPool mutex poisoned")
+        self.inner.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("BufferPool mutex was poisoned; recovering cached state");
+            poisoned.into_inner()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stats_recovers_after_mutex_poison() {
+        let pool = BufferPool::new(1024);
+
+        std::thread::scope(|scope| {
+            let handle = scope.spawn(|| {
+                let _guard = pool.lock();
+                panic!("poison BufferPool lock");
+            });
+            assert!(handle.join().is_err());
+        });
+
+        let stats = pool.stats();
+        assert_eq!(stats.cached_bytes, 0);
+        assert_eq!(stats.cached_blocks, 0);
     }
 }
 


### PR DESCRIPTION
## What

Fixes #210.

`BufferPool::lock()` currently panics if the internal mutex is poisoned. This PR changes that path to recover the poisoned guard with `into_inner()` and log a warning through `tracing` instead of cascading the panic into later pool calls.

The patch also adds a regression test that deliberately poisons a local pool lock, then verifies `stats()` can still read the pool state.

## Why

A thread panic while holding the pool lock should not permanently make normal pool operations like `stats`, `release`, `trim`, or `clear` panic. The pool state is still available through `PoisonError::into_inner()`, and recovering keeps the existing public APIs unchanged.

This also removes an `expect()` from library code in line with the repository guidance.

## How

- Replace `self.inner.lock().expect(...)` with explicit poison handling.
- Recover with `poisoned.into_inner()`.
- Add a focused unit test in `crates/mohu-buffer/src/pool.rs`.

## Verification

Passed locally:

```sh
cargo test -p mohu-buffer stats_recovers_after_mutex_poison --all-features
cargo check -p mohu-buffer --all-features
git diff --check -- crates/mohu-buffer/src/pool.rs
```

Known repo-wide CI failures are the same pre-existing failures seen on other PRs: DCO action resolution, workspace rustfmt drift, unrelated `mohu-dtype` clippy warnings, existing `pyo3` cargo-deny advisory, and cargo-machete findings across several crates.

Working on this as part of GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The buffer pool now gracefully recovers from thread synchronization failures instead of crashing, logging a warning message to help diagnose issues.

* **Tests**
  * Added test coverage to verify the buffer pool correctly recovers and reports accurate statistics following thread synchronization failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->