### PR TITLE
docs(agents): correct ci-pass aggregation to 9 blocking jobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ ci: add musl cross-compile target
 - Title = commit subject format above.
 - Target `mohu-org/mohu:main`.
 - All commits must be signed (`Signed-off-by`). DCO check blocks merge.
-- Required status: `CI Pass` (the `ci-pass` job aggregates all 13 checks).
+- Required status: `CI Pass` (the `ci-pass` job aggregates the 9 blocking checks; `semver`, `cross`, `coverage`, and `miri` are advisory and do not block merge).
 - Do not force-push after review — amend is allowed only before first review comment.
 
 ---
@@ -150,20 +150,20 @@ ci: add musl cross-compile target
 
 ## CI pipeline summary
 
-All 13 jobs must pass (aggregated under `ci-pass`):
+Of the 13 CI jobs, nine are blocking (aggregated under `ci-pass`) and four are advisory:
 
-| Job | What it checks |
-|-----|---------------|
-| `dco` | Every commit has `Signed-off-by` (PR only) |
-| `fmt` | `rustfmt` — no diff |
-| `clippy` | Zero warnings, `-D warnings` |
-| `deny` | No banned deps, no unlicensed deps, no advisories |
-| `unused-deps` | No unused `[dependencies]` entries |
-| `build` | Workspace builds with all features |
-| `doc` | Docs build with `-D warnings` |
-| `msrv` | Builds on Rust 1.85 |
-| `bench-check` | All benchmarks compile |
-| `semver` | No accidental breaking API changes (PR only) |
-| `cross` | Builds for aarch64-linux, aarch64-darwin, x86_64-musl |
-| `coverage` | Test coverage reported to Codecov |
-| `miri` | `mohu-buffer` unsafe code passes Miri strict provenance |
+| Job | Blocking | What it checks |
+|-----|----------|---------------|
+| `dco` | yes | Every commit has `Signed-off-by` (PR only) |
+| `fmt` | yes | `rustfmt` — no diff |
+| `clippy` | yes | Zero warnings, `-D warnings` |
+| `deny` | yes | No banned deps, no unlicensed deps, no advisories |
+| `unused-deps` | yes | No unused `[dependencies]` entries |
+| `build` | yes | Workspace builds with all features |
+| `doc` | yes | Docs build with `-D warnings` |
+| `msrv` | yes | Builds on Rust 1.85 |
+| `bench-check` | yes | All benchmarks compile |
+| `semver` | advisory — `continue-on-error` until crates are published | No accidental breaking API changes (PR only) |
+| `cross` | advisory — runs on push to `main` only, never on PRs | Builds for aarch64-linux, aarch64-darwin, x86_64-musl |
+| `coverage` | advisory — `continue-on-error` (Codecov upload can be flaky) | Test coverage reported to Codecov |
+| `miri` | advisory — `continue-on-error` (nightly toolchain) | `mohu-buffer` unsafe code passes Miri strict provenance |


### PR DESCRIPTION
Closes #219.

`AGENTS.md` describes the `ci-pass` job as aggregating all 13 CI jobs in two places, but the gate in `.github/workflows/ci.yml` only requires the 9 blocking jobs (`dco`, `fmt`, `clippy`, `deny`, `unused-deps`, `build`, `doc`, `msrv`, `bench-check`). The other four (`semver`, `cross`, `coverage`, `miri`) are advisory and never block merge.

A new contributor reading AGENTS.md would conclude that a red `coverage` or `miri` run gates their PR and could spend time chasing failures the maintainers have already chosen to treat as advisory.

Changes:

- `AGENTS.md` L128: name the 9 blocking jobs and call out `semver`, `cross`, `coverage`, `miri` as advisory.
- `AGENTS.md` L153 + table: add a `Blocking` column so the yes/advisory split is visible at a glance.

Verified against `.github/workflows/ci.yml`:

- `ci-pass.needs` lists 9 jobs (L227–L236) and the comment above it confirms the rule: "All blocking jobs listed here. Non-blocking jobs use continue-on-error and are excluded."
- `semver` (L132): `continue-on-error: true`
- `cross` (L150): `if: github.event_name == 'push'`
- `coverage` (L182): `continue-on-error: true`
- `miri` (L205): `continue-on-error: true`

No code or workflow change — pure docs alignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CI pipeline guidance to reflect that the aggregated “ci-pass” covers 9 of 13 jobs (instead of all 13).
  * Expanded the pipeline summary to clearly distinguish blocking vs advisory checks.
  * Clarified that checks like semver, cross, coverage, and miri are advisory (non-blocking).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->