### PR TITLE
fix(buffer): respect destination strides in copy

### DIFF
--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -19,7 +19,10 @@ use mohu_dtype::{
 };
 use mohu_error::{MohuError, MohuResult};
 
-use crate::{buffer::Buffer, strides::StridedByteIter};
+use crate::{
+    buffer::Buffer,
+    strides::{NdIndexIter, StridedByteIter},
+};
 
 // ─── fill_raw ────────────────────────────────────────────────────────────────
 
@@ -175,21 +178,37 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
                 .for_each(|(sc, dc)| dc.copy_from_slice(sc));
         }
     } else {
-        // General strided → contiguous copy.
+        // General strided copy. Pointers are already positioned at each
+        // buffer's logical element zero, so offsets here are relative.
         let src_raw = src.as_ptr();
         let dst_raw = unsafe { dst.as_mut_ptr() };
-        let dst_itemsize = dst.itemsize();
 
-        for (elem_idx, src_off) in
-            StridedByteIter::new(src.shape(), src.strides(), src.offset()).enumerate()
-        {
-            let dst_off = elem_idx * dst_itemsize;
+        let src_offsets = NdIndexIter::new(src.shape())
+            .map(|idx| relative_byte_offset(&idx, src.strides()));
+        let dst_offsets = NdIndexIter::new(dst.shape())
+            .map(|idx| relative_byte_offset(&idx, dst.strides()));
+
+        for (src_off, dst_off) in src_offsets.zip(dst_offsets) {
+            // SAFETY: matching lengths were checked above, and both relative
+            // offsets are generated from each buffer's validated layout.
             unsafe {
-                std::ptr::copy_nonoverlapping(src_raw.add(src_off), dst_raw.add(dst_off), itemsize);
+                std::ptr::copy_nonoverlapping(
+                    src_raw.offset(src_off),
+                    dst_raw.offset(dst_off),
+                    itemsize,
+                );
             }
         }
     }
     Ok(())
+}
+
+fn relative_byte_offset(indices: &[usize], strides: &[isize]) -> isize {
+    indices
+        .iter()
+        .zip(strides.iter())
+        .map(|(&idx, &stride)| idx as isize * stride)
+        .sum()
 }
 
 // ─── cast_copy ───────────────────────────────────────────────────────────────

--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -183,10 +183,10 @@ pub fn copy_to_contiguous(src: &Buffer, dst: &mut Buffer) -> MohuResult<()> {
         let src_raw = src.as_ptr();
         let dst_raw = unsafe { dst.as_mut_ptr() };
 
-        let src_offsets = NdIndexIter::new(src.shape())
-            .map(|idx| relative_byte_offset(&idx, src.strides()));
-        let dst_offsets = NdIndexIter::new(dst.shape())
-            .map(|idx| relative_byte_offset(&idx, dst.strides()));
+        let src_offsets =
+            NdIndexIter::new(src.shape()).map(|idx| relative_byte_offset(&idx, src.strides()));
+        let dst_offsets =
+            NdIndexIter::new(dst.shape()).map(|idx| relative_byte_offset(&idx, dst.strides()));
 
         for (src_off, dst_off) in src_offsets.zip(dst_offsets) {
             // SAFETY: matching lengths were checked above, and both relative

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -286,7 +286,10 @@ fn copy_from_respects_fortran_destination_strides() {
 
 #[test]
 fn copy_to_contiguous_respects_nonzero_offset_destination() {
-    let src = Buffer::from_slice(&[1_i32, 2, 3, 4]).unwrap().reshape(&[2, 2]).unwrap();
+    let src = Buffer::from_slice(&[1_i32, 2, 3, 4])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
     let mut backing = vec![-1_i32; 9];
     let itemsize = std::mem::size_of::<i32>();
     let layout = Layout::new_custom(
@@ -300,14 +303,8 @@ fn copy_to_contiguous_respects_nonzero_offset_destination() {
 
     // SAFETY: backing stays alive for the whole test, and the custom layout
     // touches only elements 4, 5, 7, and 8 within the 9-element backing Vec.
-    let mut dst = unsafe {
-        Buffer::from_raw_parts(
-            ptr,
-            backing.len() * itemsize,
-            DType::I32,
-            layout,
-        )
-    };
+    let mut dst =
+        unsafe { Buffer::from_raw_parts(ptr, backing.len() * itemsize, DType::I32, layout) };
 
     assert_eq!(dst.offset(), 4 * itemsize);
     assert!(!dst.is_c_contiguous());

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -247,6 +247,41 @@ fn copy_to_contiguous_from_transposed() {
     assert_eq!(dst.get::<f64>(&[1, 0]).unwrap(), 1.0_f64);
 }
 
+#[test]
+fn copy_to_contiguous_respects_fortran_destination_strides() {
+    let data: Vec<i32> = (1..=6).collect();
+    let src = Buffer::from_slice(&data).unwrap().reshape(&[2, 3]).unwrap();
+    let mut dst = Buffer::alloc(DType::I32, &[2, 3], Order::F).unwrap();
+
+    assert!(!dst.is_c_contiguous());
+    assert!(dst.is_f_contiguous());
+
+    ops::copy_to_contiguous(&src, &mut dst).unwrap();
+
+    assert_eq!(dst.get::<i32>(&[0, 0]).unwrap(), 1);
+    assert_eq!(dst.get::<i32>(&[0, 1]).unwrap(), 2);
+    assert_eq!(dst.get::<i32>(&[0, 2]).unwrap(), 3);
+    assert_eq!(dst.get::<i32>(&[1, 0]).unwrap(), 4);
+    assert_eq!(dst.get::<i32>(&[1, 1]).unwrap(), 5);
+    assert_eq!(dst.get::<i32>(&[1, 2]).unwrap(), 6);
+}
+
+#[test]
+fn copy_from_respects_fortran_destination_strides() {
+    let data: Vec<i32> = (10..=15).collect();
+    let src = Buffer::from_slice(&data).unwrap().reshape(&[2, 3]).unwrap();
+    let mut dst = Buffer::alloc(DType::I32, &[2, 3], Order::F).unwrap();
+
+    dst.copy_from(&src).unwrap();
+
+    assert_eq!(dst.get::<i32>(&[0, 0]).unwrap(), 10);
+    assert_eq!(dst.get::<i32>(&[0, 1]).unwrap(), 11);
+    assert_eq!(dst.get::<i32>(&[0, 2]).unwrap(), 12);
+    assert_eq!(dst.get::<i32>(&[1, 0]).unwrap(), 13);
+    assert_eq!(dst.get::<i32>(&[1, 1]).unwrap(), 14);
+    assert_eq!(dst.get::<i32>(&[1, 2]).unwrap(), 15);
+}
+
 // ── 9. Buffer pool ────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -1,7 +1,9 @@
 //! Integration tests for mohu-buffer — exercises every major subsystem.
 
+use std::ptr::NonNull;
+
 use mohu_buffer::{
-    Buffer, GLOBAL_POOL, Order, SliceArg, ops,
+    Buffer, GLOBAL_POOL, Layout, Order, SliceArg, ops,
     strides::{NdIndexIter, broadcast_strides, c_strides, f_strides},
 };
 use mohu_dtype::{DType, promote::CastMode};
@@ -280,6 +282,45 @@ fn copy_from_respects_fortran_destination_strides() {
     assert_eq!(dst.get::<i32>(&[1, 0]).unwrap(), 13);
     assert_eq!(dst.get::<i32>(&[1, 1]).unwrap(), 14);
     assert_eq!(dst.get::<i32>(&[1, 2]).unwrap(), 15);
+}
+
+#[test]
+fn copy_to_contiguous_respects_nonzero_offset_destination() {
+    let src = Buffer::from_slice(&[1_i32, 2, 3, 4]).unwrap().reshape(&[2, 2]).unwrap();
+    let mut backing = vec![-1_i32; 9];
+    let itemsize = std::mem::size_of::<i32>();
+    let layout = Layout::new_custom(
+        &[2, 2],
+        &[(3 * itemsize) as isize, itemsize as isize],
+        4 * itemsize,
+        itemsize,
+    )
+    .unwrap();
+    let ptr = NonNull::new(backing.as_mut_ptr() as *mut u8).unwrap();
+
+    // SAFETY: backing stays alive for the whole test, and the custom layout
+    // touches only elements 4, 5, 7, and 8 within the 9-element backing Vec.
+    let mut dst = unsafe {
+        Buffer::from_raw_parts(
+            ptr,
+            backing.len() * itemsize,
+            DType::I32,
+            layout,
+        )
+    };
+
+    assert_eq!(dst.offset(), 4 * itemsize);
+    assert!(!dst.is_c_contiguous());
+
+    ops::copy_to_contiguous(&src, &mut dst).unwrap();
+
+    assert_eq!(dst.get::<i32>(&[0, 0]).unwrap(), 1);
+    assert_eq!(dst.get::<i32>(&[0, 1]).unwrap(), 2);
+    assert_eq!(dst.get::<i32>(&[1, 0]).unwrap(), 3);
+    assert_eq!(dst.get::<i32>(&[1, 1]).unwrap(), 4);
+
+    drop(dst);
+    assert_eq!(backing, vec![-1, -1, -1, -1, 1, 2, -1, 3, 4]);
 }
 
 // ── 9. Buffer pool ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Fixes #238.

The slow path in `copy_to_contiguous` now walks both source and destination layouts instead of assuming the destination can be written linearly. This matters for writeable non-C destinations such as F-order buffers.

I kept the fast contiguous-to-contiguous path unchanged.

## Why

The old slow path used source strides, but wrote to:

```rust
elem_idx * dst_itemsize
```

That is only correct for C-contiguous destinations. For an F-contiguous destination with shape `[2, 3]`, logical C-order writes need to land through destination strides, otherwise callers get `Ok(())` with the wrong logical values.

`Buffer::copy_from` delegates to the same helper, so it inherits the fix.

## Verification

Passed locally:

```sh
cargo test -p mohu-buffer copy_to_contiguous_respects_fortran_destination_strides --all-features
cargo test -p mohu-buffer copy_from_respects_fortran_destination_strides --all-features
cargo test -p mohu-buffer copy_to_contiguous_from_transposed --all-features
cargo check -p mohu-buffer --all-features
git diff --check -- crates/mohu-buffer/src/ops.rs crates/mohu-buffer/tests/integration.rs
```

Known pre-existing repo failures while checking locally:

```sh
cargo clippy -p mohu-buffer --all-targets --all-features -- -D warnings
```

This still fails before reaching this change because of existing `mohu-dtype` clippy warnings in `macros.rs`, `dtype.rs`, `finfo.rs`, and `iinfo.rs`.

```sh
cargo fmt -p mohu-buffer -- --check
```

This also reports broad pre-existing rustfmt drift across `mohu-buffer` sources and examples. I did not reformat unrelated files in this PR.

Working on this as part of GSSoC 2026.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy operations now perform fully general N‑D strided element-wise copies, correctly handling non-contiguous sources/destinations, column‑major (Fortran) layout destinations, and destination buffers with non‑zero offsets.

* **Tests**
  * New integration tests validate copy semantics for column‑major destinations and writes into offset-backed destination buffers, asserting copied values and untouched backing elements remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->