### PR TITLE
docs: add README for mohu-core

### DIFF
--- a/crates/mohu-core/README.md
+++ b/crates/mohu-core/README.md
@@ -1,12 +1,12 @@
 # mohu-core
 
-'mohu-core' is a convenience crate that re-exports the core Mohu foundation crates as a single dependency.
+`mohu-core` is a convenience crate that re-exports the core Mohu foundation crates as a single dependency.
 
-Instead of depending on individual crates such as mohu-error, mohu-dtype, mohu-buffer, and mohu-array users can import them through mohu-core.
+Instead of depending on individual crates such as `mohu-error`, `mohu-dtype`, `mohu-buffer`, and `mohu-array`, users can import them through `mohu-core`.
 
 ## When to use mohu-core
 
-Use mohu-core when:
+Use `mohu-core` when:
 
 - You need functionality from multiple Mohu foundation crates.
 - You prefer a single dependency and import path.
@@ -38,4 +38,4 @@ mohu-core
 
 ## Contributing
 
-See the workspace CONTRIBUTING.md for development guidelines.
+See the workspace [CONTRIBUTING.md](../../CONTRIBUTING.md) for development guidelines.

--- a/crates/mohu-core/README.md
+++ b/crates/mohu-core/README.md
@@ -1,0 +1,41 @@
+# mohu-core
+
+'mohu-core' is a convenience crate that re-exports the core Mohu foundation crates as a single dependency.
+
+Instead of depending on individual crates such as mohu-error, mohu-dtype, mohu-buffer, and mohu-array users can import them through mohu-core.
+
+## When to use mohu-core
+
+Use mohu-core when:
+
+- You need functionality from multiple Mohu foundation crates.
+- You prefer a single dependency and import path.
+
+Use individual crates when:
+
+- You only need one specific crate.
+- You want to keep dependencies minimal.
+
+## Example
+
+```rust
+use mohu_core::*;
+
+fn main() {
+    // Access re-exported items from Mohu crates.
+}
+```
+
+## Dependency Graph
+
+```text
+mohu-core
+├── mohu-array
+├── mohu-buffer
+├── mohu-dtype
+└── mohu-error
+```
+
+## Contributing
+
+See the workspace CONTRIBUTING.md for development guidelines.


### PR DESCRIPTION
## Summary

Adds a README for mohu-core describing its purpose as a convenience crate that re-exports core Mohu foundation crates.

### Changes

* Added crate overview
* Added usage guidance
* Added example import
* Added dependency graph
* Added link to CONTRIBUTING.md

Closes #125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the mohu-core convenience crate: usage guidance, a Rust example, when to prefer this crate vs. individual crates, a dependency/re-export graph, and a pointer to contributing guidance to help new users and contributors get started.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohu-org/mohu/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->