### PR TITLE
fix(ci): repair baseline gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,23 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: christophebedard/dco-check@0.5.1
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Verify DCO sign-off
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          failed=0
+          for commit in $(git rev-list "$BASE_SHA"..HEAD); do
+            if ! git log -1 --format=%B "$commit" | grep -Eiq '^Signed-off-by: .+ <.+@.+>$'; then
+              echo "::error::commit $commit is missing a Signed-off-by line"
+              failed=1
+            fi
+          done
+          exit "$failed"
 
   # ── Gate: Formatting ────────────────────────────────────────────────────────
   fmt:
@@ -138,10 +152,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: semver
+      - run: git fetch --no-tags origin ${{ github.event.pull_request.base.sha }}
       - uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: all-features
-          baseline-rev: origin/main
+          baseline-rev: ${{ github.event.pull_request.base.sha }}
 
   # ── Cross-compilation (push to main only — too expensive per PR) ─────────────
   cross:

--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -39,24 +39,26 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'opened'
     steps:
-      # Safe: fetch-depth 0 on base ref only — no fork code executed
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-          fetch-depth: 0
-
-      - name: Get changed files via API
+      - name: Get changed files
         id: changed
-        uses: tj-actions/changed-files@v46
-        with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
-          sha: ${{ github.event.pull_request.head.sha }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          files=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+          count=$(printf '%s\n' "$files" | sed '/^$/d' | wc -l | tr -d ' ')
+          {
+            echo "all_changed_files<<EOF"
+            printf '%s\n' "$files"
+            echo "EOF"
+            echo "all_changed_files_count=$count"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Detect changed crates
         id: crates
         run: |
-          crates=$(echo "${{ steps.changed.outputs.all_changed_files }}" \
-            | tr ' ' '\n' \
+          crates=$(printf '%s\n' "${{ steps.changed.outputs.all_changed_files }}" \
             | grep -oP 'crates/[^/]+' \
             | sort -u \
             | tr '\n' ', ' \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,15 +466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,15 +569,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -925,37 +907,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -963,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -975,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1206,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -1304,12 +1281,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ serde        = { version = "1", features = ["derive"] }
 memmap2      = "0.9"
 
 # ── Python bindings ───────────────────────────────────────────────────────────
-pyo3         = { version = "0.23", features = ["extension-module"] }
+pyo3         = { version = "0.28", features = ["extension-module"] }
 
 # ── Collections ───────────────────────────────────────────────────────────────
 smallvec     = { version = "1.13", features = ["union"] }

--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -361,7 +361,7 @@ impl Buffer {
             return Self::zeros(T::DTYPE, &[0, 0]);
         }
         let cols = data[0].len();
-        for row in data.iter() {
+        for row in data {
             if row.len() != cols {
                 return Err(MohuError::ShapeMismatch {
                     expected: vec![cols],

--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -1311,9 +1311,9 @@ pub fn argmax_flat(buf: &Buffer) -> MohuResult<usize> {
 
 /// Fills a C-contiguous F32 buffer using non-temporal (streaming) AVX2 stores.
 ///
-/// Bypasses the CPU cache — achieves peak DRAM write bandwidth for buffers
-/// > a few MiB where the data will not be immediately re-read.
-/// > Falls back to the standard Rayon fill on non-x86_64 platforms.
+/// Bypasses the CPU cache to achieve peak DRAM write bandwidth for buffers
+/// larger than a few MiB where the data will not be immediately re-read.
+/// Falls back to the standard Rayon fill on non-x86_64 platforms.
 pub fn fill_nontemporal_f32_buf(buf: &mut Buffer, value: f32) -> MohuResult<()> {
     use mohu_dtype::DType;
     if buf.dtype() != DType::F32 {

--- a/crates/mohu-buffer/src/strides.rs
+++ b/crates/mohu-buffer/src/strides.rs
@@ -56,9 +56,9 @@ pub fn f_strides(shape: &[usize], itemsize: usize) -> StrideVec {
     let ndim = shape.len();
     let mut strides = StrideVec::with_capacity(ndim);
     let mut acc: isize = itemsize as isize;
-    for &s in shape {
+    for &dim in shape {
         strides.push(acc);
-        acc = acc.saturating_mul(s as isize);
+        acc = acc.saturating_mul(dim as isize);
     }
     strides
 }

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -24,14 +24,14 @@ fn ones_values() {
 
 #[test]
 fn full_fills_bytes() {
-    // full() takes raw bytes — pass f32 3.14 as bytes
-    let fill: f32 = 3.15;
+    // full() takes raw bytes, so pass a non-special f32 value as bytes.
+    let fill: f32 = 3.125;
     let buf = Buffer::full(DType::F32, &[5, 5], &fill.to_le_bytes()).unwrap();
     assert!(
         buf.as_slice::<f32>()
             .unwrap()
             .iter()
-            .all(|&x| (x - 3.15_f32).abs() < 1e-6)
+            .all(|&x| (x - 3.125_f32).abs() < 1e-6)
     );
 }
 

--- a/crates/mohu-dtype/src/dtype.rs
+++ b/crates/mohu-dtype/src/dtype.rs
@@ -525,6 +525,15 @@ impl DType {
         }
     }
 
+    /// Parses a dtype from a NumPy-compatible string.
+    ///
+    /// This preserves the older inherent constructor while [`std::str::FromStr`]
+    /// is also implemented for idiomatic `"float32".parse::<DType>()` usage.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> MohuResult<Self> {
+        Self::parse(s)
+    }
+
     /// Returns an iterator over all variants in definition order.
     pub fn all() -> impl Iterator<Item = DType> {
         ALL_DTYPES.iter().copied()


### PR DESCRIPTION
## summary

- replace the brittle dco action with an explicit signed-off-by check against the pr base sha
- make semver checks compare against the pull request base sha
- move pr summary changed-file discovery to the github api so fork prs do not depend on checkout diff state
- bump pyo3 to 0.28.3 to clear the rustsec advisory and support current python headers
- apply the repo fmt baseline and fix clippy warnings that were failing across unrelated prs

## verification

- cargo fmt --all -- --check
- cargo check --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features

## notes

old pull requests that still show previous workflow names will still need a rerun, rebase, or new commit so github records the current ci job names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PyO3 dependency version.
  * Improved CI/CD workflows for dependency checking and PR validation.

* **Refactor**
  * Optimized internal buffer operations and stride calculations.
  * Enhanced data type handling with improved API surface.

* **Tests**
  * Updated integration tests with revised validation parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->