### PR TITLE
docs(ui): enhance mdbook docs aesthetics with custom css

### DIFF
--- a/crates/mohu-buffer/src/layout.rs
+++ b/crates/mohu-buffer/src/layout.rs
@@ -122,6 +122,19 @@ fn e_reversed_empty(start: usize, stop: usize) -> bool {
 /// array view.
 ///
 /// Does not own memory — it is always paired with a backing `Buffer`.
+///
+/// # Example
+///
+/// ```
+/// use mohu_buffer::layout::Layout;
+///
+/// let shape = [2, 3];
+/// let itemsize = 4; // e.g., f32
+/// let layout = Layout::new_c(&shape, itemsize).unwrap();
+///
+/// assert_eq!(layout.shape(), &[2, 3]);
+/// assert_eq!(layout.strides(), &[12, 4]); // C-contiguous strides
+/// ```
 #[derive(Clone, PartialEq, Eq)]
 pub struct Layout {
     shape: ShapeVec,
@@ -136,12 +149,28 @@ impl Layout {
     // ─── Constructors ─────────────────────────────────────────────────────────
 
     /// Creates a C-contiguous (row-major) layout for `shape`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mohu_buffer::layout::Layout;
+    /// let layout = Layout::new_c(&[2, 3], 4).unwrap();
+    /// assert_eq!(layout.strides(), &[12, 4]);
+    /// ```
     pub fn new_c(shape: &[usize], itemsize: usize) -> MohuResult<Self> {
         let strides = c_strides(shape, itemsize);
         Self::new_custom(shape, &strides, 0, itemsize)
     }
 
     /// Creates a Fortran-contiguous (column-major) layout for `shape`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mohu_buffer::layout::Layout;
+    /// let layout = Layout::new_f(&[2, 3], 4).unwrap();
+    /// assert_eq!(layout.strides(), &[4, 8]);
+    /// ```
     pub fn new_f(shape: &[usize], itemsize: usize) -> MohuResult<Self> {
         let strides = f_strides(shape, itemsize);
         Self::new_custom(shape, &strides, 0, itemsize)

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -9,6 +9,7 @@ src         = "src"
 site-url          = "/mohu/"
 git-repository-url = "https://github.com/mohu-org/mohu"
 edit-url-template  = "https://github.com/mohu-org/mohu/edit/main/docs/{path}"
+additional-css     = ["theme/custom.css"]
 
 [output.html.fold]
 enable = true

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -1,0 +1,37 @@
+/* docs/theme/custom.css */
+:root {
+    --fonts: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+body {
+    font-family: var(--fonts);
+    letter-spacing: -0.01em;
+}
+
+/* Improve readability of main content */
+.content main {
+    max-width: 850px;
+    line-height: 1.6;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+/* Make code blocks look slightly cleaner */
+pre {
+    border-radius: 6px;
+}
+
+/* Sticky transparent menu on mobile */
+@media (max-width: 1080px) {
+    .menu-bar {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        border-bottom: 1px solid var(--sidebar-border);
+    }
+}

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -1,4 +1,7 @@
 /* docs/theme/custom.css */
+`@import` url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
+/* docs/theme/custom.css */
 :root {
     --fonts: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
This PR introduces a custom UI enhancement for the project's user-facing `mdBook` documentation.

Changes made:
- Added `docs/theme/custom.css` containing rules for modern typography (`Inter` fallback stack), tighter letter spacing, readability width limits, and a frosted-glass sticky menu for mobile views.
- Updated `docs/book.toml` to correctly load `additional-css = ["theme/custom.css"]`.

These changes significantly improve the aesthetic quality and reading experience of the `mohu` docs while maintaining full compatibility with the existing build pipeline.

Resolves #267 
Thank you for your time!
Please add the appropriate gssoc:approved , difficulty, type and quality labels. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added examples to library documentation for improved clarity.
  * Enhanced documentation site styling with improved typography, spacing, and responsive design for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->