### PR TITLE
fix(ci): enforce slash assign limits

### DIFF
--- a/.github/workflows/slash-assign.yml
+++ b/.github/workflows/slash-assign.yml
@@ -12,6 +12,9 @@ jobs:
   assign:
     name: /assign
     runs-on: ubuntu-latest
+    concurrency:
+      group: slash-assign-${{ github.repository }}
+      cancel-in-progress: false
     if: |
       startsWith(github.event.comment.body, '/assign') &&
       github.event.comment.user.type != 'Bot'
@@ -23,19 +26,55 @@ jobs:
             const issueNumber = context.payload.issue.number;
             const commenter = context.payload.comment.user.login;
 
-            const mentions = [...body.matchAll(/@([\w-]+)/g)].map(m => m[1]);
-            const assignees = mentions.length > 0 ? mentions : [commenter];
+            const comment = async (body) => {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              });
+            };
+
+            if (body !== '/assign') {
+              await comment('Usage: `/assign`. Contributors can only assign themselves.');
+              return;
+            }
+
+            if (context.payload.issue.pull_request) {
+              await comment('`/assign` is only available for issues.');
+              return;
+            }
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+
+            if (issue.assignees.length > 0) {
+              await comment(`This issue is already assigned to ${issue.assignees.map(a => `@${a.login}`).join(', ')}.`);
+              return;
+            }
+
+            const assignedIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignee: commenter,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const openIssueCount = assignedIssues.filter(issue => !issue.pull_request).length;
+            if (openIssueCount >= 5) {
+              await comment(`@${commenter}, you already have 5 open assigned issues. Complete one before claiming another.`);
+              return;
+            }
 
             await github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              assignees,
+              assignees: [commenter],
             });
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              body: `Assigned to ${assignees.map(a => `@${a}`).join(', ')} ✓`,
-            });
+            await comment(`Assigned to @${commenter}.`);


### PR DESCRIPTION
## Summary
- restrict `/assign` to self-assignment on issues
- enforce one assignee per issue
- cap contributors at five open assigned issues
- serialize assignment runs to prevent concurrent claims bypassing checks

## Verification
- `git diff --check`
- YAML parsed with Ruby Psych
- embedded `actions/github-script` JavaScript checked with an async Node wrapper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `/assign` command now requires exact match to prevent misuse
  * Restricted `/assign` to issues only; pull requests are no longer supported
  * Added validation to prevent assignment if an issue already has assignees
  * Enforced limit of 5 open assigned issues per user to prevent overload
  * Simplified assignment confirmation messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->