### PR TITLE
fix(buffer): correct reverse slice [::-1] producing empty layout

### DIFF
--- a/crates/mohu-buffer/src/layout.rs
+++ b/crates/mohu-buffer/src/layout.rs
@@ -102,6 +102,10 @@ impl SliceArg {
             let abs_step = (-step) as usize;
             if e_reversed_empty(start, stop) {
                 0
+            } else if stop == usize::MAX {
+                // Stop sentinel means "before index 0" for full reverse.
+                // Elements from start down to index 0 inclusive.
+                (start + 1).div_ceil(abs_step)
             } else {
                 start.saturating_sub(stop).div_ceil(abs_step)
             }


### PR DESCRIPTION
## What

Fix reverse slice `[::-1]` producing an empty layout on any axis (e.g., a 1D array of length 3 slicing with `[::-1]` yields 0 elements instead of 3).

## Why

For `[::-1]` the default `stop` resolves to the sentinel `usize::MAX`. The count computation used `start.saturating_sub(stop)` which saturates to 0, making the layout appear empty regardless of the actual axis length.

Closes #201

## How

In the negative-step branch of the count calculation, added a special case for `stop == usize::MAX`. When this sentinel is present (meaning "before index 0"), the count is computed as `(start + 1).div_ceil(abs_step)` — correctly counting elements from `start` down to and including index 0.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all` applied
- [ ] `CHANGELOG.md` updated (if user-facing change)
- [ ] Benchmarks added or updated (if performance-sensitive path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed element-count calculation for reversed slices when no stop boundary is specified.

* **Documentation**
  * Improved safety documentation for non-temporal memory fill operations with clearer contract specifications.

* **Chores**
  * Updated dependency configuration to allow unused licenses and multiple versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->