### PR TITLE
fix: update pyo3 to 0.29 to resolve RUSTSEC-2026-0176/0177

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -1005,18 +1005,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1024,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1036,13 +1036,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ serde        = { version = "1", features = ["derive"] }
 memmap2      = "0.9"
 
 # ── Python bindings ───────────────────────────────────────────────────────────
-pyo3         = { version = "0.28", features = ["extension-module"] }
+pyo3         = { version = "0.29", features = ["extension-module"] }
 
 # ── Collections ───────────────────────────────────────────────────────────────
 smallvec     = { version = "1.13", features = ["union"] }

--- a/deny.toml
+++ b/deny.toml
@@ -18,4 +18,4 @@ unknown-git      = "deny"
 allow-registry   = ["https://github.com/rust-lang/crates.io-index"]
 
 [advisories]
-ignore = ["RUSTSEC-2025-0020"]
+ignore = []


### PR DESCRIPTION
pyo3 0.28 is hit by two advisories published 2026-06-11, both patched in 0.29.0, so `cargo deny check advisories` fails on every PR right now:

- **RUSTSEC-2026-0176** — out-of-bounds read in `PyList`/`PyTuple` iterator `nth`/`nth_back` (affects `>= 0.24.0, < 0.29.0`)
- **RUSTSEC-2026-0177** — missing `Sync` bound on `PyCFunction::new_closure` closures (affects `>= 0.15.0, < 0.29.0`)

Both reach the tree through `mohu-error`'s optional `python` feature.

This bumps the workspace pin `0.28 -> 0.29` and updates the lockfile. The lock change is the five pyo3 crates only (`pyo3`, `pyo3-build-config`, `pyo3-ffi`, `pyo3-macros`, `pyo3-macros-backend`), each `0.28.3 -> 0.29.0` — no other dependency churn. `mohu-error` compiles unchanged against 0.29 (its only pyo3 surface is the exception-conversion API in `crates/mohu-error/src/python.rs`).

I also dropped the now-stale `RUSTSEC-2025-0020` ignore from `deny.toml`: that one was fixed in pyo3 0.24.1, so on 0.29 it matches no crate and cargo-deny emits an `advisory-not-detected` warning for it.

Verified locally with cargo-deny 0.19.8 (the version the CI action resolves), running the exact CI command:

```
$ cargo deny check advisories licenses bans sources
advisories ok, bans ok, licenses ok, sources ok
```

and `cargo check -p mohu-error --features python` is clean.

Follows the precedent of #196, which bumped pyo3 rather than ignoring the advisory.

Closes #280.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python bindings dependency to latest stable version for improved compatibility and performance.
  * Removed suppression for an advisory, indicating related issue has been resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->