### PR TITLE
docs: add project architecture section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ Polars proved you can rewrite the data layer in Rust and win. mohu is that same 
 - SIMD-accelerated math ops
 - Memory layouts NumPy can't express
 
+## project architecture
+
+this repo is organized as a cargo workspace. here's a quick map of where things live:
+
+- **`crates/`** — the actual library code, split into individual crates (core arrays, dispatch, compute kernels, I/O, etc). this is where most contributions happen.
+- **`tests/`** — integration tests that exercise the public API across crates, separate from the unit tests inside each crate.
+- **`examples/`** — small standalone programs showing how to use mohu, meant to be read and run directly.
+- **`docs/`** — longer-form documentation and design notes that don't fit in the README.
+- **`benches/`** — performance benchmarks used to track regressions and validate the "parallel by default" and zero-copy goals.
+- **`scripts/`** — developer tooling and automation scripts (setup, checks, etc) that aren't part of the library itself.
+
+mohu/
+├── crates/       # library code, one crate per component
+├── tests/        # cross-crate integration tests
+├── examples/     # runnable usage examples
+├── docs/         # extended documentation
+├── benches/      # performance benchmarks
+└── scripts/      # dev tooling and automation
+
+
 ## status
 
 Early. The foundation is being laid. If you believe the Python numerical stack deserves a rewrite, watch this repo or contribute.
@@ -36,3 +56,4 @@ Early. The foundation is being laid. If you believe the Python numerical stack d
 ## license
 
 MIT
+

--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ Early. The foundation is being laid. If you believe the Python numerical stack d
 
 ## license
 
-MIT
+MIT  
 


### PR DESCRIPTION
## What

Adds a new "Project Architecture" section to README.md, briefly explaining
the purpose of `crates/`, `tests/`, `examples/`, `docs/`, `benches/`, and
`scripts/`, plus a simple repository tree diagram.

## Why

The README currently covers vision, goals, and tech stack, but gives new
contributors no overview of how the repo is structured, making it harder to
know where to start. Closes #282.

## How

Inserted the new section between `## what's coming` and `## status`, matching
the existing README's lowercase header style and plain bullet formatting.
No code was changed — this is a documentation-only edit.

## Checklist

- [ ] `cargo test --workspace` passes — N/A, no code changed
- [ ] `cargo clippy --workspace -- -D warnings` passes — N/A, no code changed
- [x] `cargo fmt --all` applied — N/A (Markdown file, not applicable, unchanged)
- [ ] `CHANGELOG.md` updated (if user-facing change) — not applicable, internal docs addition only
- [ ] Benchmarks added or updated (if performance-sensitive path) — N/A, no performance-sensitive code touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new project architecture section to the README, outlining the repository layout and where to find key areas like library code, tests, examples, docs, benchmarks, and scripts.
  * Included a clearer directory-style view of the workspace structure.
  * Updated the license section formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->