### PR TITLE
docs: add API stability policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,43 @@
 
 Rust-powered arrays for Python. Fast, parallel, and built for the future.
 
-mohu is an early-stage NumPy replacement with its core written in Rust. The goal is simple — take everything Python's scientific stack does and do it without the bottlenecks that have been accepted for decades.
+mohu is an early-stage NumPy replacement with its core written in Rust. The goal is simple—take everything Python's scientific stack does and do it without the bottlenecks that have been accepted for decades.
 
-No GIL. No single-threaded ops. No object overhead. Just arrays.
+No GIL. No single-threaded operations. No object overhead. Just arrays.
 
-## why
+## Why
 
 NumPy is written in C and hasn't fundamentally changed in 20 years. It's single-threaded by default, its string arrays are an afterthought, and parallelism requires reaching for other tools. The Python data ecosystem deserves a better foundation.
 
 Polars proved you can rewrite the data layer in Rust and win. mohu is that same bet, one layer down.
 
-## what's coming
+## What's Coming
 
 - N-dimensional arrays with a NumPy-compatible API
 - Parallel operations by default via Rayon
-- First-class string arrays — not `dtype=object`
-- Built on Apache Arrow — interop with Polars, DuckDB, and the rest of the ecosystem out of the box
+- First-class string arrays—not `dtype=object`
+- Built on Apache Arrow for interoperability with Polars, DuckDB, and the rest of the ecosystem
 - Zero-copy Python integration via PyO3
-- SIMD-accelerated math ops
-- Memory layouts NumPy can't express
+- SIMD-accelerated math operations
+- Memory layouts NumPy cannot express
 
-## status
+## Status
 
-Early. The foundation is being laid. If you believe the Python numerical stack deserves a rewrite, watch this repo or contribute.
+Early. The foundation is being laid. If you believe the Python numerical stack deserves a rewrite, watch this repository or contribute.
 
-## built with
+## API Stability
+
+The Mohu workspace is under active development, and API stability varies across crates and features.
+
+For details about the project's API stability guarantees, supported compatibility expectations, and guidance on using public APIs, see [STABILITY.md](STABILITY.md).
+
+## Built With
 
 - [Rust](https://rust-lang.org)
 - [PyO3](https://github.com/PyO3/pyo3) — Python bindings
-- [arrow-rs](https://github.com/apache/arrow-rs) — columnar memory format
-- [Rayon](https://github.com/rayon-rs/rayon) — data parallelism
+- [arrow-rs](https://github.com/apache/arrow-rs) — Columnar memory format
+- [Rayon](https://github.com/rayon-rs/rayon) — Data parallelism
 
-## license
+## License
 
 MIT

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,21 @@
+# API Stability Policy
+
+## Overview
+
+The Mohu workspace is in an early stage of development. As the project evolves, APIs may change as functionality is added and refined.
+
+## Current Status
+
+Unless explicitly documented otherwise, public APIs should be considered **experimental** and may change between releases.
+
+## Future Stability Levels
+
+As the project matures, APIs may be classified as:
+
+- **Stable** – Intended for production use with compatibility guarantees.
+- **Experimental** – Under active development and subject to change.
+- **Internal** – Not intended for external use and may change without notice.
+
+## Versioning
+
+Mohu aims to follow Semantic Versioning (SemVer). Once APIs are designated as stable, breaking changes will be reserved for major releases.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -8,6 +8,11 @@ The Mohu workspace is in an early stage of development. As the project evolves, 
 
 Unless explicitly documented otherwise, public APIs should be considered **experimental** and may change between releases.
 
+The authoritative source for the stability status of each crate or public API is
+`CRATE_MAP.md`. It identifies whether a crate or component is considered
+**Stable**, **Experimental**, or **Internal**. Any feature-specific exceptions
+or stability overrides are also documented there.
+
 ## Future Stability Levels
 
 As the project matures, APIs may be classified as:
@@ -18,4 +23,8 @@ As the project matures, APIs may be classified as:
 
 ## Versioning
 
-Mohu aims to follow Semantic Versioning (SemVer). Once APIs are designated as stable, breaking changes will be reserved for major releases.
+Mohu aims to follow Semantic Versioning (SemVer). Once APIs are designated as
+stable, breaking changes will be reserved for major releases.
+
+Refer to `CRATE_MAP.md` to determine the current stability classification of a
+crate or API before relying on compatibility guarantees.


### PR DESCRIPTION
## What

This PR introduces API stability documentation for the Mohu workspace.

### Changes
- Added a new `STABILITY.md` document describing the project's API stability policy.
- Updated `README.md` with an **API Stability** section linking to `STABILITY.md`.
- Improved the README wording and formatting for consistency while preserving the original meaning.

## Why

The workspace currently does not document API stability guarantees, making it difficult for users to understand the maturity of public APIs.

This change addresses Issue #275 by providing a central stability policy and making it easier for users to discover it from the README.

Closes #275

## How

- Created a root-level `STABILITY.md` describing the current API stability policy.
- Added an **API Stability** section to the README.
- Standardized some README headings and wording for improved readability.

## Checklist

- `cargo test --workspace` passes *(documentation-only change; not run)*
- `cargo clippy --workspace -- -D warnings` passes *(documentation-only change; not run)*
- `cargo fmt --all` applied *(not applicable; Markdown-only changes)*
- `CHANGELOG.md` updated (not required for documentation-only changes)
- Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README wording, punctuation, and heading formatting for consistency.
  * Added an **API Stability** section to clarify how stability is handled and where to find more details.
  * Introduced a new stability policy document outlining stability levels and versioning expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->