### PR TITLE
fix(docs): resolve markdownlint and Makefile phony nits from #293

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,7 @@ These documents can help you quickly identify the appropriate crate and follow t
 | Add or update benchmarks | `benches/` |
 | Improve documentation | `docs/` |
 | Add or update tests | `tests/` or the relevant crate's `tests/` directory |
+
 ---
 
 ## Crate map

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release test lint fmt fmt-check check clean bench deny changelog
+.PHONY: build release test lint fmt fmt-check check clean bench deny changelog contrib-guide
 
 build:
 	cargo build --workspace


### PR DESCRIPTION
## What

Small follow up to #293. Two nits flagged by CodeRabbit on that PR that were left unresolved when it merged.

## Changes

- Added a blank line before the Quick Reference table's closing rule in CONTRIBUTING.md, fixes markdownlint MD058.
- Added contrib-guide to the Makefile's .PHONY list so a same named file can't suppress its documentation only recipe.

## Why

Both were called out in review on #293 but the PR merged before they were addressed. Cleaning them up directly rather than leaving them open ended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved spacing in the contributor quick reference section.

* **Chores**
  * Updated build tooling so the contributor guide command runs reliably as a standalone task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->