### PR TITLE
docs(retrieval): add ARCHITECTURE.md and mohu-retrieval crate stub

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,67 @@
+# Retrieval Architecture (Vector Search)
+
+## Status
+
+Planning stage. Tracked in [#286](https://github.com/mohu-org/mohu/issues/286).
+No retrieval backend is implemented yet. This document exists to record the
+design constraints and open questions before implementation starts, and to
+claim the `mohu-retrieval` crate namespace so future contributors have a
+clear home for this work.
+
+## Background
+
+mohu's core design pillars are:
+
+- **Rayon parallelism by default** — operations use data-parallel execution
+  without opt-in flags.
+- **Arrow-native memory layout** — arrays share memory layout with Apache
+  Arrow for zero-copy interop.
+- **Zero-copy Python interop** — no unnecessary copies at the Rust/Python
+  boundary.
+
+Vector similarity search (approximate nearest-neighbor / ANN retrieval) is a
+common downstream use case for an array library like mohu, but no retrieval
+backend currently exists in this repository.
+
+## Why this needs a design decision before implementation
+
+The most widely-adopted ANN library, [FAISS](https://github.com/facebookresearch/faiss),
+conflicts with mohu's design pillars in ways worth deciding on deliberately
+rather than discovering after the fact:
+
+1. **Not Arrow-native.** FAISS operates on contiguous float32 NumPy arrays
+   with its own C++ memory layout. Using it from Arrow-backed mohu arrays
+   would require an explicit copy at the index boundary (Arrow column →
+   NumPy contiguous → FAISS), breaking the zero-copy goal.
+2. **Single-threaded by default.** FAISS's Python bindings build indexes
+   single-threaded (`IndexFlatL2`, `IndexIVFFlat`) unless
+   `faiss.omp_set_num_threads()` is set explicitly, and it manages its own
+   C++/OpenMP thread pool rather than integrating with Rayon.
+3. **Not implemented in this repo.** There is currently no retrieval code
+   (FAISS-based or otherwise) anywhere in this codebase to build on top of.
+
+## Options under discussion
+
+- **(a) A Rust-native ANN library** — e.g. [`usearch`](https://github.com/unum-cloud/usearch)
+  or [`hnswlib`](https://github.com/nmslib/hnswlib) bindings — both have more
+  Rust-friendly, Arrow-compatible buffer interfaces than FAISS.
+- **(b) Wrap FAISS carefully** — with an explicit, clearly-documented
+  Arrow → flat-copy boundary, accepting the copy as an unavoidable interop
+  cost rather than pretending it doesn't exist.
+- **(c) A native mohu implementation** — e.g. a Rayon-parallel HNSW index
+  built as a `mohu-retrieval` crate, consistent with the rest of the
+  workspace's "parallel by default" design.
+
+No decision has been made yet — see issue #286 for ongoing discussion.
+
+## This crate (`crates/mohu-retrieval`)
+
+Currently an empty placeholder. It exists to:
+
+- Reserve the `mohu-retrieval` namespace in the workspace.
+- Signal where Arrow-native vector search is intended to live once a design
+  is chosen.
+- Give contributors following up on #286 a starting point instead of an
+  ambiguous "where does this go?" question.
+
+No behavior is implemented. This is intentionally additive-only.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "mohu-retrieval"
+version = "0.1.0"
+
+[[package]]
 name = "mohu-simd"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ members = [
     # ── I/O & interop ─────────────────────────────────────────────────────────
     "crates/mohu-io",         # .npy / .npz / CSV / HDF5 / Parquet
 
+    # ── Retrieval (placeholder — see ARCHITECTURE.md, issue #286) ─────────────
+    "crates/mohu-retrieval",  # vector similarity search / ANN retrieval
+
     # ── Developer tooling ─────────────────────────────────────────────────────
     "crates/mohu-testing",    # test fixtures, property tests, array comparison
 ]
@@ -66,8 +69,9 @@ mohu-sparse  = { path = "crates/mohu-sparse",  version = "0.1.0" }
 mohu-masked  = { path = "crates/mohu-masked",  version = "0.1.0" }
 
 # ── Internal crates — I/O & tooling ──────────────────────────────────────────
-mohu-io      = { path = "crates/mohu-io",      version = "0.1.0" }
-mohu-testing = { path = "crates/mohu-testing", version = "0.1.0" }
+mohu-io        = { path = "crates/mohu-io",        version = "0.1.0" }
+mohu-testing   = { path = "crates/mohu-testing",   version = "0.1.0" }
+mohu-retrieval = { path = "crates/mohu-retrieval", version = "0.1.0" }
 
 # ── External mohu-org crates (separate repos) ─────────────────────────────────
 mohu-compute = { git = "https://github.com/mohu-org/mohu-compute" }

--- a/crates/mohu-retrieval/Cargo.toml
+++ b/crates/mohu-retrieval/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name        = "mohu-retrieval"
+description = "Vector similarity search / ANN retrieval (planned — not yet implemented)"
+version.workspace     = true
+edition.workspace     = true
+license.workspace     = true
+authors.workspace     = true
+repository.workspace  = true
+homepage.workspace    = true
+keywords.workspace    = true
+categories.workspace  = true
+
+[dependencies]

--- a/crates/mohu-retrieval/src/lib.rs
+++ b/crates/mohu-retrieval/src/lib.rs
@@ -1,0 +1,7 @@
+//! Vector similarity search / approximate nearest-neighbor (ANN) retrieval.
+//!
+//! This crate is a placeholder claiming the `mohu-retrieval` namespace.
+//! No retrieval backend is implemented yet — see `ARCHITECTURE.md` at the
+//! repository root for the design discussion and open questions (FAISS vs.
+//! `usearch`/`hnswlib` vs. a native Rayon-parallel HNSW implementation)
+//! tracked in issue #286.


### PR DESCRIPTION
## What

Adds `ARCHITECTURE.md` documenting the retrieval design constraints, and an empty `crates/mohu-retrieval` stub to reserve the namespace. Addresses part of #286.

## Why

mohu's design pillars (Rayon parallelism by default, Arrow-native memory layout, zero-copy Python interop) conflict with FAISS, the most widely-adopted ANN library — it's not Arrow-native and is single-threaded by default. Before any retrieval backend gets implemented, it's worth documenting that conflict and the options under discussion, and giving contributors a clear crate to build toward instead of an ambiguous "where does this go?" question.

## How

- `ARCHITECTURE.md`: documents the pillar conflict, and the three options raised in #286 (Rust-native ANN library like `usearch`/`hnswlib`, a carefully-wrapped FAISS with an explicit copy boundary, or a native Rayon-parallel HNSW implementation as a mohu crate). No decision is made here — this is scoping, not a design doc for an implementation.
- `crates/mohu-retrieval`: empty placeholder crate, registered in the workspace, to reserve the namespace.

**Important — scope note:** #286 also asks to relocate a root-level `vector_store.py` into `examples/faiss_integration/`. I checked (`git log --all -- "*vector_store.py*"`, plus a repo-wide grep for `faiss`) and this file doesn't exist anywhere in this repo's history — there's no FAISS code, and nothing to relocate. This PR covers only the documentation and crate-stub portions of the issue. Happy to close out the rest of #286 once there's clarity on whether that file was expected to exist already or is part of unstarted future work.

## Checklist
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all` applied
- [ ] `CHANGELOG.md` updated (if user-facing change) — not user-facing, no behavior change
- [ ] Benchmarks added or updated (if performance-sensitive path) — not applicable, no implementation