### PR TITLE
fix(deps): raise rustfft and rand version floors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,10 +84,10 @@ num-complex  = "0.4"
 num-integer  = "0.1"
 
 # ── FFT ───────────────────────────────────────────────────────────────────────
-rustfft      = "6"
+rustfft      = "6.4.1"
 
 # ── PRNG ─────────────────────────────────────────────────────────────────────
-rand         = { version = "0.9", features = ["small_rng"] }
+rand         = { version = "0.9.4", features = ["small_rng"] }
 rand_chacha  = "0.9"
 
 # ── Sparse / linear algebra utilities ────────────────────────────────────────


### PR DESCRIPTION
## What

* Raises the minimum supported `rustfft` version from `6` to `6.4.1`.
* Raises the minimum supported `rand` version from `0.9` to `0.9.4`.
* Preserves the existing `small_rng` feature.
* Keeps the change limited to the affected declarations in `Cargo.toml`.

## Why

The existing Cargo requirements use compatible version ranges:

* `rustfft = "6"` allows compatible `6.x` releases.
* `rand = "0.9"` allows compatible `0.9.x` releases.

Although `Cargo.lock` already resolves `rustfft 6.4.1` and `rand 0.9.4`, the manifest still permits resolution to older compatible versions.

Raising the version floors ensures that dependency resolution cannot fall below the currently validated releases while still allowing future semver-compatible updates.

Closes #273

## How

* Updated `rustfft` to `6.4.1`.
* Updated `rand` to `0.9.4`.
* Preserved the existing features and dependency configuration.
* Confirmed that `Cargo.lock` requires no change because it already resolves both requested versions.
* Rebased the branch onto the latest `upstream/main`.

The following checks passed:

* `cargo metadata --locked --format-version 1`
* `cargo fmt --all -- --check`
* `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
* `cargo test --locked --workspace --all-features`
* `RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --all-features`
* `cargo bench --locked --workspace --no-run --all-features`
* `cargo machete`
* `git diff --check`

`cargo deny check` currently fails on the existing `upstream/main` lockfile because of these pre-existing advisories:

* `RUSTSEC-2026-0204` for `crossbeam-epoch 0.9.18`
* `RUSTSEC-2026-0186` for `memmap2 0.9.10`

This PR does not modify `Cargo.lock` or either affected dependency.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all` applied
- [x] `CHANGELOG.md` updated (not required; this is not a user-facing change)
- [x] Benchmarks added or updated (not applicable; no performance-sensitive code was changed, and existing benchmarks compile successfully)
