### PR TITLE
fix(deps): update memmap2 and crossbeam-epoch for RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -638,9 +638,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
The `Cargo Deny` job has been failing on every pull request, which fails `CI Pass` and causes `Build & Test`, `Miri`, and `Coverage` to be skipped. No PR has been mergeable since July as a result.

Two advisories are responsible:

- **RUSTSEC-2026-0176 / RUSTSEC-2026-0177** — `memmap2` 0.9.10, reached via `mohu-buffer` (mmap feature). Fixed in 0.9.11.
- **RUSTSEC-2026-0204** — `crossbeam-epoch` 0.9.18, reached transitively through `rayon` → `rayon-core` → `crossbeam-deque`. Invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`. Fixed in 0.9.20.

Both resolved with `cargo update -p <crate>`; lockfile only, no manifest or source changes.

## Verification

```
cargo deny check   # advisories ok, bans ok, licenses ok, sources ok
cargo test --workspace   # 83 passing, 0 failing
```

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo machete` are also clean.

Sending this on its own so it can merge ahead of the open PR backlog it unblocks.