### PR TITLE
docs: rewrite README, add crate READMEs, and enforce MSRV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -638,9 +638,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ resolver = "2"
 [workspace.package]
 version      = "0.1.0"
 edition      = "2024"
+rust-version = "1.85"
 license      = "MIT"
 authors      = ["mohu contributors"]
 repository   = "https://github.com/mohu-org/mohu"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ one layer down.
 **Pre-alpha. Not usable as a NumPy replacement yet, and not published to crates.io or
 PyPI.** The memory foundation is real and tested; the compute layers above it are
 scaffolded but largely unimplemented. This table is the honest state of the workspace —
-if a crate says *stub*, its source files are empty.
+if a crate says *stub*, its implementation modules contain no public implementation.
 
 | Crate | What it does | State |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -1,36 +1,202 @@
+<div align="center">
+
 # mohu
 
-Rust-powered arrays for Python. Fast, parallel, and built for the future.
+**Rust-powered arrays for Python. Fast, parallel, and built for the future.**
 
-mohu is an early-stage NumPy replacement with its core written in Rust. The goal is simple—take everything Python's scientific stack does and do it without the bottlenecks that have been accepted for decades.
+[![CI](https://github.com/mohu-org/mohu/actions/workflows/ci.yml/badge.svg)](https://github.com/mohu-org/mohu/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![MSRV](https://img.shields.io/badge/rustc-1.85%2B-orange.svg)](rust-toolchain.toml)
+[![Edition](https://img.shields.io/badge/edition-2024-lightgrey.svg)](Cargo.toml)
+[![good first issues](https://img.shields.io/github/issues/mohu-org/mohu/good%20first%20issue?color=7057ff&label=good%20first%20issues)](https://github.com/mohu-org/mohu/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+
+[Quickstart](#quickstart) · [Status](#status) · [Architecture](#architecture) · [Contributing](#contributing) · [Roadmap](ROADMAP.md)
+
+</div>
+
+---
+
+mohu is an early-stage NumPy replacement with its core written in Rust. The goal is
+simple — take everything Python's scientific stack does and do it without the
+bottlenecks that have been accepted for decades.
 
 No GIL. No single-threaded operations. No object overhead. Just arrays.
 
 ## Why
 
-NumPy is written in C and hasn't fundamentally changed in 20 years. It's single-threaded by default, its string arrays are an afterthought, and parallelism requires reaching for other tools. The Python data ecosystem deserves a better foundation.
+NumPy is written in C and hasn't fundamentally changed in 20 years. It's
+single-threaded by default, its string arrays are an afterthought, and parallelism
+requires reaching for other tools. The Python data ecosystem deserves a better
+foundation.
 
-Polars proved you can rewrite the data layer in Rust and win. mohu is that same bet, one layer down.
+Polars proved you can rewrite the data layer in Rust and win. mohu is that same bet,
+one layer down.
+
+## Status
+
+**Pre-alpha. Not usable as a NumPy replacement yet, and not published to crates.io or
+PyPI.** The memory foundation is real and tested; the compute layers above it are
+scaffolded but largely unimplemented. This table is the honest state of the workspace —
+if a crate says *stub*, its source files are empty.
+
+| Crate | What it does | State |
+|---|---|---|
+| `mohu-error` | `MohuError`, error codes, context chains, reporter | ✅ implemented |
+| `mohu-dtype` | 15 dtypes, scalar traits, promotion, `finfo`/`iinfo`, DLPack codes | ✅ implemented |
+| `mohu-buffer` | Aligned/mmap allocation, layout, strides, views, DLPack, pool | ✅ implemented |
+| `mohu-random` | PCG64 / Philox PRNG + distributions | 🟡 partial |
+| `mohu-array` | `NdArray<T>` — the user-facing array type | ⬜ stub |
+| `mohu-core` | Re-export facade over the foundation crates | ⬜ stub |
+| `mohu-simd` | AVX2 / AVX-512 / NEON kernels | ⬜ stub |
+| `mohu-ufunc` | Universal-function protocol: broadcast, reduce, outer | ⬜ stub |
+| `mohu-index` | Fancy / boolean indexing, take & put | ⬜ stub |
+| `mohu-ops` | Element-wise arithmetic, comparison, reductions, matmul | ⬜ stub |
+| `mohu-fft` | FFT / IFFT / RFFT / 2-D FFT | ⬜ stub |
+| `mohu-special` | erf, gamma, beta, Bessel | ⬜ stub |
+| `mohu-stats` | Descriptive statistics, hypothesis tests | ⬜ stub |
+| `mohu-sparse` | COO / CSR / CSC formats | ⬜ stub |
+| `mohu-masked` | Masked arrays, null propagation | ⬜ stub |
+| `mohu-io` | `.npy` / `.npz` / CSV / Arrow IPC / HDF5 / Parquet | ⬜ stub |
+| `mohu-testing` | Fixtures, property strategies, array comparison | ⬜ stub |
+
+Companion repositories: [`mohu-compute`](https://github.com/mohu-org/mohu-compute)
+(SIMD kernels), [`mohu-linalg`](https://github.com/mohu-org/mohu-linalg)
+(decompositions and solvers), [`mohu-py`](https://github.com/mohu-org/mohu-py)
+(PyO3 bindings). All three are scaffolded and awaiting implementation.
+
+Every stub in the table above is an open issue. If you want to build one, see
+[Contributing](#contributing).
+
+## Quickstart
+
+mohu is not on crates.io yet, so build from source:
+
+```bash
+git clone https://github.com/mohu-org/mohu.git
+cd mohu
+cargo build --workspace
+cargo test --workspace
+```
+
+Today the usable surface is `mohu-buffer` — the strided, dtype-tagged, reference-counted
+buffer that every future `NdArray` sits on top of:
+
+```rust
+use mohu_buffer::{Buffer, Order};
+use mohu_dtype::{CastMode, DType};
+
+// Build a 2x3 buffer from a typed slice. dtype is inferred from T.
+let a = Buffer::from_slice_2d::<f32>(&[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]])?;
+
+// Views are zero-copy: transpose only rewrites the stride vector.
+let t = a.transpose();
+assert_eq!(t.shape(), &[3, 2]);
+assert_eq!(t.get::<f32>(&[2, 1])?, 6.0);
+
+// Constructors mirror NumPy.
+let z = Buffer::zeros(DType::F64, &[3, 4])?;
+let r = Buffer::arange(0.0, 10.0, 2.0, DType::I32)?;
+assert_eq!(r.to_vec::<i32>()?, vec![0, 2, 4, 6, 8]);
+
+// Casting is explicit and checked against a promotion policy.
+let as_f64 = a.cast(DType::F64, CastMode::Safe)?;
+
+// Broadcasting produces a zero-copy view with 0-strides.
+let row = Buffer::from_slice::<f32>(&[10.0, 20.0, 30.0])?;
+let bcast = row.broadcast_to(&[2, 3])?;
+assert_eq!(bcast.strides(), &[0, 4]);
+
+// Fortran-order allocation is a first-class option, not an afterthought.
+let f = Buffer::alloc(DType::F32, &[2, 3], Order::F)?;
+assert!(f.is_f_contiguous());
+# Ok::<(), mohu_error::MohuError>(())
+```
+
+That snippet is a compiled example, not prose — run it with:
+
+```bash
+cargo run --example quickstart
+```
+
+Other runnable examples:
+
+```bash
+cargo run --example buffer_basics    # construction, views, reshape, slicing
+cargo run --example alloc_and_pool   # allocation strategies and the buffer pool
+cargo run --example dtype_basics     # the 15 dtypes and their metadata
+cargo run --example type_promotion   # NumPy-compatible promotion rules
+```
+
+## Architecture
+
+mohu is a Cargo workspace of small, single-responsibility crates layered by dependency
+depth. Nothing in a lower layer knows about anything above it.
+
+```
+Foundation      mohu-error → mohu-dtype → mohu-buffer → mohu-array → mohu-core
+Dispatch        mohu-simd, mohu-ufunc, mohu-index
+Compute         mohu-ops, mohu-fft, mohu-random, mohu-special, mohu-stats
+Structures      mohu-sparse, mohu-masked
+I/O             mohu-io
+Tooling         mohu-testing
+```
+
+Three design decisions drive the rest:
+
+- **Buffers are dtype-tagged at runtime, monomorphised at the call site.** A `Buffer`
+  carries a `DType` enum rather than a generic parameter, and the `dispatch_dtype!`
+  macro family expands a runtime tag into a static generic call — dynamic typing at the
+  API boundary, zero vtables in the hot loop.
+- **Layout is separate from storage.** `Layout` owns shape, strides, and offset;
+  `Buffer` owns bytes. Transpose, reshape, slice, broadcast, squeeze, and `expand_dims`
+  are all layout rewrites that allocate nothing.
+- **Arrow-native memory.** Allocations are SIMD-aligned and use Arrow's validity-bitmap
+  conventions, so zero-copy interchange with Polars, DuckDB, and anything speaking
+  DLPack or the Arrow C data interface is a pointer handoff.
+
+For the crate-by-crate public API surface, see [CRATE_MAP.md](CRATE_MAP.md). Design
+documents live in [`docs/design/`](docs/design/) and accepted proposals in
+[`docs/rfcs/`](docs/rfcs/).
 
 ## What's Coming
 
 - N-dimensional arrays with a NumPy-compatible API
 - Parallel operations by default via Rayon
-- First-class string arrays—not `dtype=object`
+- First-class string arrays — not `dtype=object`
 - Built on Apache Arrow for interoperability with Polars, DuckDB, and the rest of the ecosystem
 - Zero-copy Python integration via PyO3
 - SIMD-accelerated math operations
 - Memory layouts NumPy cannot express
 
-## Status
+See [ROADMAP.md](ROADMAP.md) for the sequenced plan.
 
-Early. The foundation is being laid. If you believe the Python numerical stack deserves a rewrite, watch this repository or contribute.
+## Contributing
+
+Contributions are welcome, and the stub crates above are the fastest way in.
+
+```bash
+make fmt      # rustfmt
+make lint     # clippy, warnings denied
+make test     # workspace test suite
+make bench    # criterion benchmarks
+```
+
+Start here:
+
+- [Good first issues](https://github.com/mohu-org/mohu/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — scoped, single-file tasks with acceptance criteria
+- [CONTRIBUTING.md](CONTRIBUTING.md) — workflow, branch naming, commit conventions, review expectations
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+
+All commits must be signed off for [DCO](https://developercertificate.org/)
+(`git commit -s`), and CI enforces formatting, clippy, MSRV 1.85, semver, docs,
+Miri, and `cargo-deny`.
 
 ## API Stability
 
-The Mohu workspace is under active development, and API stability varies across crates and features.
-
-For details about the project's API stability guarantees, supported compatibility expectations, and guidance on using public APIs, see [STABILITY.md](STABILITY.md).
+The mohu workspace is under active development, and API stability varies across crates
+and features. Nothing here is covered by semver guarantees before 1.0. See
+[STABILITY.md](STABILITY.md) for the details, and [SECURITY.md](SECURITY.md) for
+vulnerability reporting.
 
 ## Built With
 
@@ -41,4 +207,4 @@ For details about the project's API stability guarantees, supported compatibilit
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/crates/mohu-array/Cargo.toml
+++ b/crates/mohu-array/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-array"
 description = "NdArray<T> — the core N-dimensional array type composing dtype, buffer, shape, and slice info"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-buffer/Cargo.toml
+++ b/crates/mohu-buffer/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name        = "mohu-buffer"
 description = "Raw buffer allocation, memory layout, and stride arithmetic for mohu arrays"
+readme      = "README.md"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-buffer/README.md
+++ b/crates/mohu-buffer/README.md
@@ -1,0 +1,87 @@
+# mohu-buffer
+
+Raw buffer allocation, memory layout, and stride arithmetic — the memory foundation of
+[mohu](https://github.com/mohu-org/mohu). Every ndarray in `mohu-array` ultimately holds
+a `Buffer` from this crate.
+
+The central idea is that **layout is separate from storage**. `Layout` owns shape,
+strides, and offset; `Buffer` owns bytes and a `DType` tag. Transpose, reshape, slice,
+broadcast, squeeze, and `expand_dims` are layout rewrites — they allocate nothing and
+copy nothing.
+
+## Layers
+
+| Module | Responsibility |
+|---|---|
+| `alloc` | Aligned heap and mmap allocation, global live-byte stats |
+| `strides` | Stride computation, N-dim index iteration, broadcast rules |
+| `layout` | Shape + stride + offset descriptor, all view operations |
+| `buffer` | Reference-counted typed buffer, DLPack import and export |
+| `view` | Typed lifetime-bound views — `BufferView<T>`, `BufferViewMut<T>` |
+| `ops` | Parallel fill, copy, cast, scan, gather/scatter via Rayon |
+| `pool` | Allocation reuse pool and the `GLOBAL_POOL` singleton |
+
+## Usage
+
+```rust
+use mohu_buffer::{Buffer, Order};
+use mohu_dtype::{CastMode, DType};
+
+// Build a 2x3 buffer from a typed slice. dtype is inferred from T.
+let a = Buffer::from_slice_2d::<f32>(&[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]])?;
+
+// Views are zero-copy: transpose only rewrites the stride vector.
+let t = a.transpose();
+assert_eq!(t.shape(), &[3, 2]);
+assert_eq!(t.get::<f32>(&[2, 1])?, 6.0);
+
+// Constructors mirror NumPy.
+let r = Buffer::arange(0.0, 10.0, 2.0, DType::I32)?;
+assert_eq!(r.to_vec::<i32>()?, vec![0, 2, 4, 6, 8]);
+
+// Broadcasting produces a zero-copy view with 0-strides.
+let row = Buffer::from_slice::<f32>(&[10.0, 20.0, 30.0])?;
+assert_eq!(row.broadcast_to(&[2, 3])?.strides(), &[0, 4]);
+
+// Fortran order is a first-class option, not an afterthought.
+assert!(Buffer::alloc(DType::F32, &[2, 3], Order::F)?.is_f_contiguous());
+# Ok::<(), mohu_error::MohuError>(())
+```
+
+## Allocation
+
+Allocations are 64-byte aligned (`SIMD_ALIGN`) so kernels can assume aligned loads.
+Buffers above `MMAP_THRESHOLD` (1 MiB) switch from the heap to `mmap` automatically;
+`Strategy` lets a caller force either path. `AllocStats` tracks live bytes globally, and
+`BufferPool` recycles freed allocations by size class to keep steady-state workloads off
+the system allocator.
+
+## Interop
+
+`Buffer::to_dlpack()` exports a `DLManagedTensor` for zero-copy handoff to PyTorch,
+JAX, CuPy, and anything else speaking DLPack. Imported buffers are marked external and
+are not freed by mohu.
+
+## Sharing and copy-on-write
+
+`Buffer::share()` bumps a refcount rather than copying. `make_unique()` performs the
+copy only when a writer needs exclusive ownership, and `is_shared()` reports whether a
+buffer currently has other owners.
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `mmap` | yes | Enables `memmap2`-backed allocation for large buffers |
+
+## Examples
+
+```bash
+cargo run --example quickstart       # the workspace README quickstart
+cargo run --example buffer_basics    # construction, views, reshape, slicing
+cargo run --example alloc_and_pool   # allocation strategies and the buffer pool
+```
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).

--- a/crates/mohu-buffer/examples/quickstart.rs
+++ b/crates/mohu-buffer/examples/quickstart.rs
@@ -1,0 +1,41 @@
+//! The README quickstart, kept here so it is compiled and run by CI.
+//!
+//! Run with: `cargo run --example quickstart`
+
+use mohu_buffer::{Buffer, Order};
+use mohu_dtype::{CastMode, DType};
+
+fn main() -> mohu_buffer::MohuResult<()> {
+    // Build a 2x3 buffer from a typed slice. dtype is inferred from T.
+    let a = Buffer::from_slice_2d::<f32>(&[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]])?;
+    println!("a: dtype={} shape={:?}", a.dtype(), a.shape());
+
+    // Views are zero-copy: transpose only rewrites the stride vector.
+    let t = a.transpose();
+    println!("a.T: shape={:?} strides={:?}", t.shape(), t.strides());
+    assert_eq!(t.get::<f32>(&[2, 1])?, 6.0);
+
+    // Constructors mirror NumPy.
+    let z = Buffer::zeros(DType::F64, &[3, 4])?;
+    let r = Buffer::arange(0.0, 10.0, 2.0, DType::I32)?;
+    println!("zeros: {:?}, arange: {:?}", z.shape(), r.to_vec::<i32>()?);
+
+    // Casting is explicit and checked against a promotion policy.
+    let as_f64 = a.cast(DType::F64, CastMode::Safe)?;
+    println!("cast f32 -> {}", as_f64.dtype());
+
+    // Broadcasting produces a zero-copy view with 0-strides.
+    let row = Buffer::from_slice::<f32>(&[10.0, 20.0, 30.0])?;
+    let bcast = row.broadcast_to(&[2, 3])?;
+    println!(
+        "broadcast: shape={:?} strides={:?}",
+        bcast.shape(),
+        bcast.strides()
+    );
+
+    // Fortran-order allocation is a first-class option, not an afterthought.
+    let f = Buffer::alloc(DType::F32, &[2, 3], Order::F)?;
+    println!("F-order contiguous: {}", f.is_f_contiguous());
+
+    Ok(())
+}

--- a/crates/mohu-buffer/tests/readme_snippets.rs
+++ b/crates/mohu-buffer/tests/readme_snippets.rs
@@ -1,0 +1,48 @@
+//! Compile-checks the snippets and stated constants in this crate's README.md
+//! (and the workspace README quickstart) so they cannot rot.
+
+use mohu_buffer::{Buffer, MMAP_THRESHOLD, Order, SIMD_ALIGN};
+use mohu_dtype::{CastMode, DType};
+
+#[test]
+fn readme_usage_snippet() -> mohu_buffer::MohuResult<()> {
+    let a = Buffer::from_slice_2d::<f32>(&[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]])?;
+
+    let t = a.transpose();
+    assert_eq!(t.shape(), &[3, 2]);
+    assert_eq!(t.get::<f32>(&[2, 1])?, 6.0);
+
+    let r = Buffer::arange(0.0, 10.0, 2.0, DType::I32)?;
+    assert_eq!(r.to_vec::<i32>()?, vec![0, 2, 4, 6, 8]);
+
+    let row = Buffer::from_slice::<f32>(&[10.0, 20.0, 30.0])?;
+    assert_eq!(row.broadcast_to(&[2, 3])?.strides(), &[0, 4]);
+
+    assert!(Buffer::alloc(DType::F32, &[2, 3], Order::F)?.is_f_contiguous());
+
+    // Also exercised by the workspace README quickstart.
+    let z = Buffer::zeros(DType::F64, &[3, 4])?;
+    assert_eq!(z.shape(), &[3, 4]);
+    assert_eq!(a.cast(DType::F64, CastMode::Safe)?.dtype(), DType::F64);
+
+    Ok(())
+}
+
+#[test]
+fn readme_stated_constants() {
+    assert_eq!(SIMD_ALIGN, 64, "README documents 64-byte SIMD alignment");
+    assert_eq!(
+        MMAP_THRESHOLD,
+        1024 * 1024,
+        "README documents a 1 MiB mmap threshold"
+    );
+}
+
+#[test]
+fn readme_sharing_semantics() -> mohu_buffer::MohuResult<()> {
+    let a = Buffer::from_slice::<f32>(&[1.0, 2.0, 3.0])?;
+    let b = a.share();
+    assert!(a.is_shared(), "share() must not deep-copy");
+    drop(b);
+    Ok(())
+}

--- a/crates/mohu-core/Cargo.toml
+++ b/crates/mohu-core/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-core"
 description = "Re-export facade — depends on mohu-dtype, mohu-buffer, and mohu-array for convenience"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-dtype/Cargo.toml
+++ b/crates/mohu-dtype/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name        = "mohu-dtype"
 description = "DType enum, scalar type traits, and type promotion rules for mohu"
+readme      = "README.md"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-dtype/README.md
+++ b/crates/mohu-dtype/README.md
@@ -1,0 +1,87 @@
+# mohu-dtype
+
+The data type system for [mohu](https://github.com/mohu-org/mohu) — the bridge between
+Rust's static type system and the dynamic typing a NumPy-compatible array API requires.
+
+`DType` is a runtime tag; `Scalar` is the compile-time trait hierarchy. The
+`dispatch_dtype!` macro family turns the former into the latter, so a runtime dtype
+becomes a monomorphised generic call with no vtable and no branch in the inner loop.
+
+## The 15 dtypes
+
+`Bool`, `I8`, `I16`, `I32`, `I64`, `U8`, `U16`, `U32`, `U64`, `F16`, `BF16`, `F32`,
+`F64`, `C64`, `C128` — exposed as the `DType` enum, plus `ALL_DTYPES` and
+`DTYPE_COUNT` for exhaustive iteration.
+
+## What's in it
+
+| Module | Purpose |
+|---|---|
+| `dtype` | `DType`, `ALL_DTYPES`, `DTYPE_COUNT` |
+| `scalar` | `Scalar` (sealed) plus `RealScalar`, `IntScalar`, `SignedScalar`, `UnsignedScalar`, `FloatScalar`, `ComplexScalar` |
+| `promote` | `promote()`, `result_type()`, `common_type()`, `can_cast()`, `weak_promote()`, `minimum_scalar_type()`, `CastMode` |
+| `cast` | `cast_scalar()`, `cast_slice()`, saturating float→int conversion |
+| `finfo` | `FloatInfo` — machine precision metadata, analogous to `numpy.finfo` |
+| `iinfo` | `IntInfo` — integer range metadata, analogous to `numpy.iinfo` |
+| `dlpack` | DLPack type and device codes for zero-copy interchange |
+| `compat` | `ByteOrder` and NumPy-compatible dtype string names |
+| `macros` | `dtype_of!`, the `dispatch_*!` family, `for_each_dtype!`, `require_*!` |
+
+## Usage
+
+Promotion follows NumPy's rules, so mixed-dtype arithmetic resolves the way users
+already expect:
+
+```rust
+use mohu_dtype::{DType, promote, can_cast, CastMode};
+
+assert_eq!(promote(DType::I32, DType::F32), DType::F64);
+assert!(can_cast(DType::I32, DType::F64, CastMode::Safe));
+assert!(!can_cast(DType::F64, DType::I32, CastMode::Safe));
+```
+
+`CastMode` controls how permissive a conversion may be — `Safe` allows only
+value-preserving casts, `SameKind` allows narrowing within a kind, and `Unsafe` allows
+anything.
+
+## Dispatch
+
+`dispatch_dtype!` takes a runtime `DType` and the name of a macro to invoke with the
+corresponding Rust type:
+
+```rust
+use mohu_dtype::{DType, dispatch_dtype};
+
+macro_rules! size_of_ty {
+    ($t:ty) => { std::mem::size_of::<$t>() };
+}
+
+fn size_of_dtype(dt: DType) -> usize {
+    dispatch_dtype!(dt, size_of_ty)
+}
+
+assert_eq!(size_of_dtype(DType::F64), 8);
+assert_eq!(size_of_dtype(DType::C128), 16);
+```
+
+It expands to a match over all 15 dtypes, monomorphising the body once per type. The
+narrower `dispatch_numeric!`, `dispatch_integer!`, `dispatch_float!`,
+`dispatch_real!`, and `dispatch_signed!` variants restrict the match to a subset.
+
+## Features
+
+| Feature | Effect |
+|---|---|
+| `serde` | `Serialize` / `Deserialize` for `DType` |
+| `arrow` | Conversion to and from `arrow::datatypes::DataType` |
+
+## Examples
+
+```bash
+cargo run --example dtype_basics
+cargo run --example type_promotion
+```
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).

--- a/crates/mohu-dtype/tests/readme_snippets.rs
+++ b/crates/mohu-dtype/tests/readme_snippets.rs
@@ -1,0 +1,26 @@
+//! Compile-checks the snippets in this crate's README.md so they cannot rot.
+
+use mohu_dtype::{CastMode, DType, can_cast, dispatch_dtype, promote};
+
+#[test]
+fn readme_promotion_snippet() {
+    assert_eq!(promote(DType::I32, DType::F32), DType::F64);
+    assert!(can_cast(DType::I32, DType::F64, CastMode::Safe));
+    assert!(!can_cast(DType::F64, DType::I32, CastMode::Safe));
+}
+
+macro_rules! size_of_ty {
+    ($t:ty) => {
+        std::mem::size_of::<$t>()
+    };
+}
+
+fn size_of_dtype(dt: DType) -> usize {
+    dispatch_dtype!(dt, size_of_ty)
+}
+
+#[test]
+fn readme_dispatch_snippet() {
+    assert_eq!(size_of_dtype(DType::F64), 8);
+    assert_eq!(size_of_dtype(DType::C128), 16);
+}

--- a/crates/mohu-error/Cargo.toml
+++ b/crates/mohu-error/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name        = "mohu-error"
 description = "Shared error types for mohu — zero-dependency foundation used by every crate"
+readme      = "README.md"
 version.workspace    = true
 edition.workspace    = true
+rust-version.workspace = true
 license.workspace    = true
 authors.workspace    = true
 repository.workspace = true

--- a/crates/mohu-error/README.md
+++ b/crates/mohu-error/README.md
@@ -1,0 +1,59 @@
+# mohu-error
+
+Unified error handling for the [mohu](https://github.com/mohu-org/mohu) workspace.
+
+This is the foundation crate — it depends on nothing inside mohu, and every other crate
+returns its `MohuResult<T>`. Keeping one error enum for the whole workspace means a
+shape error raised deep inside a SIMD kernel surfaces to Python as the same typed,
+inspectable value it started as.
+
+## What's in it
+
+| Type | Purpose |
+|------|---------|
+| `MohuError` | The central non-exhaustive error enum — every mohu function returns this |
+| `MohuResult<T>` | `Result<T, MohuError>` alias |
+| `ErrorCode` | Stable numeric code for programmatic branching across the FFI boundary |
+| `ErrorKind` | Coarse category: `Usage`, `Runtime`, `System`, `Internal` |
+| `ErrorChain` | Iterator over nested `Context` wrappers |
+| `MultiError` | Accumulates multiple errors in a single validation pass |
+| `ErrorReporter` | Rich terminal formatting — compact, full, or JSON |
+| `ResultExt` | `.context()` / `.with_context()` extension trait |
+
+Errors are organised by domain — shape, dtype, index, buffer, compute, I/O, DLPack,
+Arrow, Python — so callers can branch on a domain without matching every variant.
+
+## Usage
+
+```rust
+use mohu_error::{MohuError, MohuResult, ResultExt, ensure};
+
+fn safe_divide(a: f64, b: f64) -> MohuResult<f64> {
+    ensure!(b != 0.0, MohuError::DivisionByZero);
+    Ok(a / b)
+}
+
+fn compute() -> MohuResult<f64> {
+    safe_divide(1.0, 0.0).context("while normalising the input row")
+}
+```
+
+The `bail!`, `ensure!`, `assert_shape_eq!`, `assert_axis_valid!`, and
+`assert_in_bounds!` macros cover the precondition checks that would otherwise be
+repeated in every kernel.
+
+## Features
+
+| Feature | Effect |
+|---|---|
+| `python` | Enables PyO3 exception conversion — `MohuError` maps onto the matching Python builtin |
+
+## Testing helpers
+
+`mohu_error::test_utils` provides `assert_err()`, `assert_ok()`, `assert_err_code()`,
+`assert_err_kind()`, `assert_shape_err()`, and `assert_chain_depth()` for asserting on
+error values without hand-rolling match arms in tests.
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).

--- a/crates/mohu-error/tests/readme_snippets.rs
+++ b/crates/mohu-error/tests/readme_snippets.rs
@@ -1,0 +1,18 @@
+//! Compile-checks the snippets in this crate's README.md so they cannot rot.
+
+use mohu_error::{MohuError, MohuResult, ResultExt, ensure};
+
+fn safe_divide(a: f64, b: f64) -> MohuResult<f64> {
+    ensure!(b != 0.0, MohuError::DivisionByZero);
+    Ok(a / b)
+}
+
+fn compute() -> MohuResult<f64> {
+    safe_divide(1.0, 0.0).context("while normalising the input row")
+}
+
+#[test]
+fn readme_usage_snippet() {
+    assert_eq!(safe_divide(6.0, 2.0).unwrap(), 3.0);
+    assert!(compute().is_err());
+}

--- a/crates/mohu-fft/Cargo.toml
+++ b/crates/mohu-fft/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-fft"
 description = "FFT, IFFT, RFFT, and 2-D transforms for mohu arrays"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-index/Cargo.toml
+++ b/crates/mohu-index/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-index"
 description = "Advanced indexing for mohu: fancy, boolean mask, take/put, slice objects"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-io/Cargo.toml
+++ b/crates/mohu-io/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-io"
 description = "Array serialization and I/O: .npy/.npz, CSV, Apache Arrow IPC, and memory-mapped files"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-masked/Cargo.toml
+++ b/crates/mohu-masked/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-masked"
 description = "Masked arrays — null / invalid value propagation for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-ops/Cargo.toml
+++ b/crates/mohu-ops/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-ops"
 description = "Element-wise arithmetic, comparison, logical, and broadcasting operations for mohu arrays"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-random/Cargo.toml
+++ b/crates/mohu-random/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-random"
 description = "PRNG engines and statistical distributions for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-simd/Cargo.toml
+++ b/crates/mohu-simd/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-simd"
 description = "AVX2 / AVX-512 / NEON SIMD kernel primitives for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-sparse/Cargo.toml
+++ b/crates/mohu-sparse/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-sparse"
 description = "COO / CSR / CSC sparse matrix formats and operations for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-special/Cargo.toml
+++ b/crates/mohu-special/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-special"
 description = "Special mathematical functions for mohu: erf, gamma, beta, Bessel, …"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-stats/Cargo.toml
+++ b/crates/mohu-stats/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-stats"
 description = "Statistical functions: descriptive stats, distributions, random sampling, and hypothesis testing"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-testing/Cargo.toml
+++ b/crates/mohu-testing/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-testing"
 description = "Test utilities, fixtures, and property-test helpers for mohu"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true

--- a/crates/mohu-ufunc/Cargo.toml
+++ b/crates/mohu-ufunc/Cargo.toml
@@ -3,6 +3,7 @@ name        = "mohu-ufunc"
 description = "Universal-function protocol for mohu: broadcast, reduce, accumulate, outer"
 version.workspace     = true
 edition.workspace     = true
+rust-version.workspace = true
 license.workspace     = true
 authors.workspace     = true
 repository.workspace  = true


### PR DESCRIPTION
Prepares the repository to be shown publicly. The README was the weakest part of the first impression: it described what mohu will be, but gave a visitor no way to tell what actually works today, no way to build it, and no example to run.

Stacked on #312 (the RUSTSEC lockfile fix) so CI is green here. That commit drops out of this diff once #312 merges.

## Workspace README

- Badges for CI, license, MSRV, edition, and open `good first issue` count
- **An honest status table for all 17 crates.** `Status: Early` is replaced with per-crate ✅ implemented / 🟡 partial / ⬜ stub. Three crates are real (`mohu-error`, `mohu-dtype`, `mohu-buffer`); the rest are stubs, and the README now says so. A contributor can pick a target in seconds instead of cloning to find out.
- A quickstart that builds from source and shows the usable surface (`mohu-buffer`)
- An architecture section covering the three decisions that shape everything else: runtime dtype tags with monomorphised dispatch, layout separated from storage, and Arrow-native memory
- Pointers to `CRATE_MAP.md`, `docs/design/`, `docs/rfcs/`, and the Makefile targets

Addresses the substance of #305, #300, #284, #245, #241, and #156.

## Crate READMEs

Adds `README.md` for `mohu-error`, `mohu-dtype`, and `mohu-buffer` — the three implemented crates — and wires each into its manifest via `readme = "README.md"` so crates.io renders them at publish time. Closes #51, #52, #63.

## Documented examples are compiled, not prose

Every snippet in every README added here is backed by a real target, so they cannot drift from the API:

- `crates/mohu-buffer/examples/quickstart.rs` — the workspace README quickstart verbatim
- `tests/readme_snippets.rs` in all three crates

These assert on documented constants too, so a change to `SIMD_ALIGN` or `MMAP_THRESHOLD` fails CI instead of silently making the README wrong. Test count goes 83 → 89.

## MSRV made real

The MSRV badge claimed 1.85 and CI pinned 1.85, but no manifest declared it, so `cargo` never enforced it — a dependency requiring a newer toolchain would have been caught only by the CI job, not locally. Adds `rust-version` to `[workspace.package]` and `rust-version.workspace = true` to all 17 crates. `cargo metadata` now reports 17/17 at 1.85. Closes #30.

## Verification

```
cargo fmt --all --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace                          # 89 passing, 0 failing
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
cargo deny check                                # advisories ok, bans ok, licenses ok, sources ok
cargo bench --workspace --no-run --all-features
cargo machete                                   # no unused dependencies
```

No source or behavior changes outside the added examples and tests.

---

One note for maintainers, not part of this PR: #271 and #298 report `edition = "2024"` as invalid and build-breaking, and #308/#309 appear to be chasing it. Edition 2024 has been stable since Rust 1.85 and the workspace builds and passes CI on it. Those issues look incorrect and are worth closing before the working config gets "fixed".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded project documentation with installation, usage, architecture, roadmap, contribution, licensing, and API stability guidance.
  - Added detailed guides for buffers, data types, and error handling.
  - Included runnable quickstart examples and usage snippets.

- **Tests**
  - Added automated checks validating documented examples and core workflows, including broadcasting, casting, sharing, dtype promotion, and error propagation.

- **Chores**
  - Standardized the minimum supported Rust version across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->