### PR TITLE
test(error): cover reporter formats

### DIFF
--- a/crates/mohu-error/src/lib.rs
+++ b/crates/mohu-error/src/lib.rs
@@ -52,3 +52,5 @@ pub use reporter::{ErrorReporter, ReportMode, Severity};
 
 /// The universal result type used by every mohu crate.
 pub type MohuResult<T> = std::result::Result<T, MohuError>;
+#[cfg(test)]
+mod reporter_tests;

--- a/crates/mohu-error/src/reporter_tests.rs
+++ b/crates/mohu-error/src/reporter_tests.rs
@@ -1,4 +1,4 @@
-use crate::{reporter::ErrorReporter, MohuError};
+use crate::{MohuError, reporter::ErrorReporter};
 
 #[test]
 fn compact_report_includes_message() {
@@ -26,8 +26,6 @@ fn json_report_contains_message_field() {
 
     assert!(result.contains("\"message\""));
     assert!(result.contains("json error"));
-    
-
 }
 
 #[test]

--- a/crates/mohu-error/src/reporter_tests.rs
+++ b/crates/mohu-error/src/reporter_tests.rs
@@ -1,0 +1,40 @@
+use crate::{reporter::ErrorReporter, MohuError};
+
+#[test]
+fn compact_report_includes_message() {
+    let error = MohuError::Internal("compact error".into());
+
+    let result = format!("{}", ErrorReporter::compact(&error));
+
+    assert!(result.contains("compact error"));
+}
+
+#[test]
+fn full_report_includes_message() {
+    let error = MohuError::Internal("full error".into());
+
+    let result = format!("{}", ErrorReporter::full(&error));
+
+    assert!(result.contains("full error"));
+}
+
+#[test]
+fn json_report_contains_message_field() {
+    let error = MohuError::Internal("json error".into());
+
+    let result = format!("{}", ErrorReporter::json(&error));
+
+    assert!(result.contains("\"message\""));
+    assert!(result.contains("json error"));
+    
+
+}
+
+#[test]
+fn severity_returns_fatal_for_internal_error() {
+    let error = MohuError::Internal("severity error".into());
+
+    let severity = error.severity().to_string();
+
+    assert_eq!(severity, "fatal");
+}


### PR DESCRIPTION
Maintainer integration of stacked PRs #160 and #161. Registers contributor-authored reporter format/severity tests, applies formatting, and validates the complete test module against current main. Original contributors: @maitreyee6803.