### PR TITLE
test(buffer): cover allocation statistics

### DIFF
--- a/crates/mohu-buffer/tests/alloc_stats_tests.rs
+++ b/crates/mohu-buffer/tests/alloc_stats_tests.rs
@@ -1,8 +1,16 @@
+use std::sync::{Mutex, OnceLock};
+
+fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+}
+
 use mohu_buffer::{AllocStats, Buffer};
 use mohu_dtype::DType;
 
 #[test]
 fn single_allocation_increments_count_and_bytes() {
+    let _lock = test_lock();
     let before = AllocStats::snapshot();
 
     let _buf = Buffer::zeros(DType::F64, &[100]).unwrap();
@@ -18,6 +26,7 @@ fn single_allocation_increments_count_and_bytes() {
 
 #[test]
 fn drop_decrements_live_bytes() {
+    let _lock = test_lock();
     let before = AllocStats::snapshot();
 
     {
@@ -33,6 +42,7 @@ fn drop_decrements_live_bytes() {
 
 #[test]
 fn clone_increments_alloc_count() {
+    let _lock = test_lock();
     let before = AllocStats::snapshot();
 
     let buf = Buffer::zeros(DType::F64, &[50]).unwrap();
@@ -40,11 +50,12 @@ fn clone_increments_alloc_count() {
 
     let after = AllocStats::snapshot();
 
-    assert_eq!(after.alloc_count, before.alloc_count + 2);
+    assert_eq!(after.alloc_count, before.alloc_count + 1);
 }
 
 #[test]
 fn zero_size_allocation() {
+    let _lock = test_lock();
     let before = AllocStats::snapshot();
 
     let _buf = Buffer::zeros(DType::F64, &[]).unwrap();

--- a/crates/mohu-buffer/tests/alloc_stats_tests.rs
+++ b/crates/mohu-buffer/tests/alloc_stats_tests.rs
@@ -13,7 +13,7 @@ fn single_allocation_increments_count_and_bytes() {
 
     assert_eq!(alloc_delta, 1);
 
-    assert_ne!(after.live_bytes, before.live_bytes);
+    assert!(after.live_bytes > before.live_bytes);
 }
 
 #[test]
@@ -28,7 +28,7 @@ fn drop_decrements_live_bytes() {
 
     assert!(after.free_count >= before.free_count + 1);
 
-    assert!(after.live_bytes <= before.live_bytes + 200 * std::mem::size_of::<f64>() as i64);
+    assert!(after.live_bytes <= before.live_bytes);
 }
 
 #[test]

--- a/crates/mohu-buffer/tests/alloc_stats_tests.rs
+++ b/crates/mohu-buffer/tests/alloc_stats_tests.rs
@@ -40,7 +40,7 @@ fn clone_increments_alloc_count() {
 
     let after = AllocStats::snapshot();
 
-    assert_eq!(after.alloc_count, before.alloc_count + 1);
+    assert_eq!(after.alloc_count, before.alloc_count + 2);
 }
 
 #[test]

--- a/crates/mohu-buffer/tests/alloc_stats_tests.rs
+++ b/crates/mohu-buffer/tests/alloc_stats_tests.rs
@@ -1,0 +1,57 @@
+use mohu_buffer::{AllocStats, Buffer};
+use mohu_dtype::DType;
+
+#[test]
+fn single_allocation_increments_count_and_bytes() {
+    let before = AllocStats::snapshot();
+
+    let _buf = Buffer::zeros(DType::F64, &[100]).unwrap();
+
+    let after = AllocStats::snapshot();
+
+    let alloc_delta = after.alloc_count - before.alloc_count;
+
+    assert_eq!(alloc_delta, 1);
+
+    assert_ne!(after.live_bytes, before.live_bytes);
+}
+
+#[test]
+fn drop_decrements_live_bytes() {
+    let before = AllocStats::snapshot();
+
+    {
+        let _buf = Buffer::zeros(DType::F64, &[200]).unwrap();
+    }
+
+    let after = AllocStats::snapshot();
+
+    assert!(after.free_count >= before.free_count + 1);
+
+    assert!(after.live_bytes <= before.live_bytes + 200 * std::mem::size_of::<f64>() as i64);
+}
+
+#[test]
+fn clone_increments_alloc_count() {
+    let before = AllocStats::snapshot();
+
+    let buf = Buffer::zeros(DType::F64, &[50]).unwrap();
+    let _clone = buf.clone();
+
+    let after = AllocStats::snapshot();
+
+    assert_eq!(after.alloc_count, before.alloc_count + 1);
+}
+
+#[test]
+fn zero_size_allocation() {
+    let before = AllocStats::snapshot();
+
+    let _buf = Buffer::zeros(DType::F64, &[]).unwrap();
+
+    let after = AllocStats::snapshot();
+
+    assert!(after.alloc_count >= before.alloc_count);
+
+    assert!(after.live_bytes >= before.live_bytes);
+}


### PR DESCRIPTION
Maintainer integration of #169. Preserves the contributor allocation-stat tests, corrects the shallow-clone allocation expectation, and serializes tests because counters are process-global atomics. Targeted tests pass. Local workspace clippy still exposes pre-existing Rust 1.94 baseline findings outside this diff.