### PR TITLE
ci(security): add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 3 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (Rust)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: codeql
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+
+      - name: Build workspace
+        run: cargo build --workspace --all-features
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:rust"


### PR DESCRIPTION
Clean current-main integration of #304. Adds the contributor-authored dedicated Rust CodeQL workflow with least-necessary workflow permissions, explicit workspace build, PR/main/scheduled/manual triggers, and SARIF analysis. Historical PR checks demonstrated CodeQL analysis success; this integration obtains fresh checks. Original contributor: @aaniya22.