### PR TITLE
feat(buffer): add shape predicates

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -646,6 +646,22 @@ impl Buffer {
     pub fn is_contiguous(&self) -> bool {
         self.layout.is_contiguous()
     }
+    /// Returns true if the buffer is 0D (a scalar).
+    pub fn is_scalar_shape(&self) -> bool {
+        self.ndim() == 0
+    }
+    /// Returns true if the buffer is 1D (a vector).
+    pub fn is_vector(&self) -> bool {
+        self.ndim() == 1
+    }
+    /// Returns true if the buffer is 2D (a matrix).
+    pub fn is_matrix(&self) -> bool {
+        self.ndim() == 2
+    }
+    /// Returns true if the buffer is 2D and both dimensions are equal.
+    pub fn is_square(&self) -> bool {
+        self.ndim() == 2 && self.shape()[0] == self.shape()[1]
+    }
     /// Returns `true` if the backing memory is SIMD-aligned.
     pub fn is_aligned(&self) -> bool {
         self.flags.contains(BufferFlags::ALIGNED)

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -400,3 +400,19 @@ fn nd_index_iter_c_order() {
     assert_eq!(indices[3].as_slice(), &[1, 0]);
     assert_eq!(indices[5].as_slice(), &[1, 2]);
 }
+#[test]
+fn shape_predicates_cover_common_shapes() {
+    let v = Buffer::from_slice(&[1_i32, 2]).unwrap();
+    assert!(v.is_vector());
+    assert!(!v.is_matrix());
+    let m = v.reshape(&[1, 2]).unwrap();
+    assert!(m.is_matrix());
+    assert!(!m.is_square());
+    let q = Buffer::from_slice(&[1_i32, 2, 3, 4])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    assert!(q.is_square());
+    let s = Buffer::zeros(DType::F64, &[]).unwrap();
+    assert!(s.is_scalar_shape());
+}


### PR DESCRIPTION
Clean current-main integration of #258. Adds Buffer scalar/vector/matrix/square predicates with focused integration coverage for scalar, vector, rectangular, and square shapes. Original contributor: @prince0-7.