### PR TITLE
fix(buffer): validate DLPack metadata

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -110,6 +110,16 @@ struct DLExportCtx {
 }
 
 /// C-ABI DLManagedTensor (DLPack v0.8).
+#[repr(align(64))]
+struct ZeroSizeSentinel([u8; 64]);
+
+static ZERO_SIZE_SENTINEL: ZeroSizeSentinel = ZeroSizeSentinel([0; 64]);
+
+/// Returns non-null, SIMD-aligned storage suitable as a zero-byte sentinel.
+fn zero_size_ptr() -> NonNull<u8> {
+    NonNull::from(&ZERO_SIZE_SENTINEL.0[0])
+}
+
 #[repr(C)]
 pub struct DLManagedTensor {
     pub dl_tensor: DLTensor,
@@ -186,7 +196,7 @@ impl RawBuffer {
             AllocHandle::alloc(nbytes, SIMD_ALIGN)?
         };
         let ptr = if nbytes == 0 {
-            NonNull::dangling()
+            zero_size_ptr()
         } else {
             handle.as_non_null()?
         };
@@ -472,35 +482,78 @@ impl Buffer {
 
         let dtype = DType::from_dlpack(tensor_dtype.code, tensor_dtype.bits, tensor_dtype.lanes)?;
 
+        if tensor_ndim < 0 {
+            return Err(MohuError::DLPackInvalid(
+                "DLTensor.ndim must be non-negative".to_string(),
+            ));
+        }
         let ndim = tensor_ndim as usize;
-        let byte_offset = tensor_byte_offset as usize;
-        let base_ptr = unsafe { (tensor_data as *mut u8).add(byte_offset) };
-        let ptr = NonNull::new(base_ptr)
-            .ok_or_else(|| MohuError::DLPackInvalid("DLTensor.data is null".to_string()))?;
+        if ndim > 0 && tensor_shape.is_null() {
+            return Err(MohuError::DLPackInvalid(
+                "DLTensor.shape is null for non-zero ndim".to_string(),
+            ));
+        }
+        let byte_offset = usize::try_from(tensor_byte_offset).map_err(|_| {
+            MohuError::DLPackInvalid("DLTensor.byte_offset does not fit usize".to_string())
+        })?;
 
         let shape: Vec<usize> = if ndim == 0 {
             vec![]
         } else {
+            // SAFETY: non-zero ndim was checked with non-null shape above; the
+            // caller's DLPack contract guarantees ndim readable shape entries.
             unsafe { std::slice::from_raw_parts(tensor_shape, ndim) }
                 .iter()
-                .map(|&d| d as usize)
-                .collect()
+                .map(|&d| {
+                    usize::try_from(d).map_err(|_| {
+                        MohuError::DLPackInvalid(
+                            "DLTensor.shape contains a negative dimension".to_string(),
+                        )
+                    })
+                })
+                .collect::<MohuResult<Vec<_>>>()?
         };
+
+        let size = shape
+            .iter()
+            .try_fold(1usize, |size, &dim| size.checked_mul(dim))
+            .ok_or_else(|| {
+                MohuError::DLPackInvalid("DLTensor shape size overflows usize".to_string())
+            })?;
 
         // Build layout from DLPack strides (element counts → bytes).
         let layout = if tensor_strides.is_null() {
             Layout::new_c(&shape, dtype.itemsize())?
         } else {
+            // SAFETY: non-null strides with ndim entries is required by DLPack.
             let raw_strides = unsafe { std::slice::from_raw_parts(tensor_strides, ndim) };
             let byte_strides: Vec<isize> = raw_strides
                 .iter()
-                .map(|&s| (s * dtype.itemsize() as i64) as isize)
-                .collect();
+                .map(|&s| {
+                    s.checked_mul(dtype.itemsize() as i64)
+                        .and_then(|s| isize::try_from(s).ok())
+                        .ok_or_else(|| {
+                            MohuError::DLPackInvalid(
+                                "DLTensor.strides overflow byte stride".to_string(),
+                            )
+                        })
+                })
+                .collect::<MohuResult<Vec<_>>>()?;
             Layout::new_custom(&shape, &byte_strides, 0, dtype.itemsize())?
         };
 
-        let size = layout.size();
-        let nbytes = size * dtype.itemsize();
+        let nbytes = size
+            .checked_mul(dtype.itemsize())
+            .ok_or_else(|| MohuError::DLPackInvalid("DLTensor size overflows usize".to_string()))?;
+        let ptr = if nbytes == 0 {
+            zero_size_ptr()
+        } else {
+            // SAFETY: non-empty DLPack data must be valid for byte_offset plus
+            // the imported layout span, as required by from_dlpack's contract.
+            let base_ptr = unsafe { (tensor_data as *mut u8).add(byte_offset) };
+            NonNull::new(base_ptr)
+                .ok_or_else(|| MohuError::DLPackInvalid("DLTensor.data is null".to_string()))?
+        };
 
         let raw = Arc::new(unsafe { RawBuffer::from_dlpack_ptr(managed, ptr, nbytes) });
         let mut flags = Self::compute_flags(&raw, &layout);

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -434,3 +434,88 @@ fn shape_predicates_cover_common_shapes() {
     let s = Buffer::zeros(DType::F64, &[]).unwrap();
     assert!(s.is_scalar_shape());
 }
+
+#[test]
+fn dlpack_zero_size_null_data_is_valid_and_deleter_runs() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+    unsafe extern "C" fn deleter(ptr: *mut mohu_buffer::DLManagedTensor) {
+        if ptr.is_null() {
+            return;
+        }
+        unsafe {
+            let shape = (*ptr).dl_tensor.shape as *mut i64;
+            if !shape.is_null() {
+                drop(Vec::from_raw_parts(shape, 1, 1));
+            }
+            drop(Box::from_raw(ptr));
+        }
+        DROPS.fetch_add(1, Ordering::SeqCst);
+    }
+    DROPS.store(0, Ordering::SeqCst);
+    let shape = Box::into_raw(Box::new([0_i64])) as *const i64;
+    let managed = Box::into_raw(Box::new(mohu_buffer::DLManagedTensor {
+        dl_tensor: mohu_buffer::DLTensor {
+            data: std::ptr::null_mut(),
+            device: mohu_buffer::RawDLDevice {
+                device_type: 1,
+                device_id: 0,
+            },
+            ndim: 1,
+            dtype: mohu_buffer::RawDLDataType {
+                code: 2,
+                bits: 64,
+                lanes: 1,
+            },
+            shape,
+            strides: std::ptr::null(),
+            byte_offset: 0,
+        },
+        manager_ctx: std::ptr::null_mut(),
+        deleter: Some(deleter),
+    }));
+    let buffer = unsafe { Buffer::from_dlpack(managed) }.unwrap();
+    assert_eq!(buffer.shape(), &[0]);
+    assert_eq!(buffer.nbytes(), 0);
+    assert!(!buffer.as_ptr().is_null());
+    assert_eq!((buffer.as_ptr() as usize) % std::mem::align_of::<f64>(), 0);
+    assert!(buffer.as_slice::<f64>().unwrap().is_empty());
+    drop(buffer);
+    assert_eq!(DROPS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn dlpack_rejects_negative_ndim_before_pointer_reads() {
+    unsafe extern "C" fn deleter(ptr: *mut mohu_buffer::DLManagedTensor) {
+        if !ptr.is_null() {
+            unsafe {
+                drop(Box::from_raw(ptr));
+            }
+        }
+    }
+    let managed = Box::into_raw(Box::new(mohu_buffer::DLManagedTensor {
+        dl_tensor: mohu_buffer::DLTensor {
+            data: std::ptr::null_mut(),
+            device: mohu_buffer::RawDLDevice {
+                device_type: 1,
+                device_id: 0,
+            },
+            ndim: -1,
+            dtype: mohu_buffer::RawDLDataType {
+                code: 2,
+                bits: 64,
+                lanes: 1,
+            },
+            shape: std::ptr::null(),
+            strides: std::ptr::null(),
+            byte_offset: 0,
+        },
+        manager_ctx: std::ptr::null_mut(),
+        deleter: Some(deleter),
+    }));
+    let result = unsafe { Buffer::from_dlpack(managed) };
+    assert!(matches!(result, Err(MohuError::DLPackInvalid(_))));
+    unsafe {
+        deleter(managed);
+    }
+}


### PR DESCRIPTION
Adds narrow DLPack import validation for negative dimensions, missing shape metadata, integer overflow, checked byte offsets/strides, and zero-size tensors with the spec-required NULL data pointer. Adds lifecycle and malformed-metadata regression tests. This is an adjacent safety repair discovered while auditing issue #6; it does not change #6 classification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DLPack tensor validation to reject invalid metadata and prevent overflow-related errors.
  * Correctly handles zero-size tensors with null data pointers.
  * Returns clear invalid-input errors for negative ranks, dimensions, and values that cannot be represented safely.

* **Tests**
  * Added coverage for zero-size tensor handling and deleter execution.
  * Added validation that invalid tensor ranks are rejected safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->