### PR TITLE
fix(buffer): honor sum axis dtype policy

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -1492,6 +1492,10 @@ impl Buffer {
 
     /// Sums over `axis`, returning a buffer with that axis collapsed.
     ///
+    /// Integer and boolean inputs use fixed-width wrapping accumulation. F16
+    /// and BF16 accumulate in F32, then round back to their input dtype.
+    /// Floating and complex outputs preserve their input dtype.
+    ///
     /// If `keepdims` is true, the result has a size-1 axis in place of `axis`.
     pub fn sum_axis(&self, axis: usize, keepdims: bool) -> MohuResult<Self> {
         if axis >= self.ndim() {
@@ -1500,7 +1504,8 @@ impl Buffer {
                 self.ndim()
             )));
         }
-        // Build output shape
+
+        let policy = SumPolicy::for_dtype(self.dtype);
         let mut out_shape: Vec<usize> = self.shape().to_vec();
         let axis_size = out_shape[axis];
         if keepdims {
@@ -1509,23 +1514,15 @@ impl Buffer {
             out_shape.remove(axis);
         }
 
-        let out = Self::zeros(DType::F64, &out_shape)?;
-        let out_raw = unsafe { out.as_mut_ptr() as *mut f64 };
-        let _ = out.len(); // shape check only; iteration is index-driven
-
-        // For each output element, sum the corresponding slice along axis.
-        // Iterate over all positions in the output.
-        use crate::strides::NdIndexIter;
-        let out_shape_full: Vec<usize> = out.shape().to_vec();
-
-        // Build src index from out index by inserting the axis.
+        let out = Self::zeros(policy.output, &out_shape)?;
+        let out_raw = unsafe { out.as_mut_ptr() };
         let itemsize = self.dtype.itemsize();
         let src_raw = self.as_ptr();
 
-        for (out_flat, out_idx) in NdIndexIter::new(&out_shape_full).enumerate() {
-            let mut acc = 0.0f64;
+        use crate::strides::NdIndexIter;
+        for (out_flat, out_idx) in NdIndexIter::new(out.shape()).enumerate() {
+            let mut acc = SumAccumulator::zero(policy.accumulator);
             for k in 0..axis_size {
-                // Build source index
                 let mut src_idx = out_idx.to_vec();
                 if keepdims {
                     src_idx[axis] = k;
@@ -1533,13 +1530,14 @@ impl Buffer {
                     src_idx.insert(axis, k);
                 }
                 let off = self.layout.byte_offset(&src_idx)?;
-                // Read element as f64 via dispatch
-                let val = read_as_f64(unsafe { src_raw.add(off) }, self.dtype, itemsize);
-                acc += val;
+                let value = read_sum_value(unsafe { src_raw.add(off) }, self.dtype, itemsize);
+                acc.add(value);
             }
-            unsafe {
-                out_raw.add(out_flat).write(acc);
-            }
+            write_sum_value(
+                unsafe { out_raw.add(out_flat * policy.output.itemsize()) },
+                policy.output,
+                acc,
+            );
         }
 
         Ok(out)
@@ -2067,6 +2065,121 @@ fn dtype_one_bytes(dtype: DType) -> Vec<u8> {
     }
     use mohu_dtype::dispatch_dtype;
     dispatch_dtype!(dtype, one_bytes)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SumAccumulator {
+    I64(i64),
+    U64(u64),
+    F32(f32),
+    F64(f64),
+    C64(num_complex::Complex<f32>),
+    C128(num_complex::Complex<f64>),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SumPolicy {
+    output: DType,
+    accumulator: DType,
+}
+
+impl SumPolicy {
+    fn for_dtype(dtype: DType) -> Self {
+        let (output, accumulator) = match dtype {
+            DType::Bool | DType::I8 | DType::I16 | DType::I32 | DType::I64 => {
+                (DType::I64, DType::I64)
+            },
+            DType::U8 | DType::U16 | DType::U32 | DType::U64 => (DType::U64, DType::U64),
+            DType::F16 | DType::BF16 => (dtype, DType::F32),
+            DType::F32 => (DType::F32, DType::F32),
+            DType::F64 => (DType::F64, DType::F64),
+            DType::C64 => (DType::C64, DType::C64),
+            DType::C128 => (DType::C128, DType::C128),
+        };
+        Self {
+            output,
+            accumulator,
+        }
+    }
+}
+
+impl SumAccumulator {
+    fn zero(dtype: DType) -> Self {
+        match dtype {
+            DType::I64 => Self::I64(0),
+            DType::U64 => Self::U64(0),
+            DType::F32 => Self::F32(0.0),
+            DType::F64 => Self::F64(0.0),
+            DType::C64 => Self::C64(num_complex::Complex::new(0.0, 0.0)),
+            DType::C128 => Self::C128(num_complex::Complex::new(0.0, 0.0)),
+            _ => unreachable!("sum accumulator dtype must be widened numeric dtype"),
+        }
+    }
+
+    fn add(&mut self, value: Self) {
+        match (self, value) {
+            (Self::I64(a), Self::I64(b)) => *a = a.wrapping_add(b),
+            (Self::U64(a), Self::U64(b)) => *a = a.wrapping_add(b),
+            (Self::F32(a), Self::F32(b)) => *a += b,
+            (Self::F64(a), Self::F64(b)) => *a += b,
+            (Self::C64(a), Self::C64(b)) => *a += b,
+            (Self::C128(a), Self::C128(b)) => *a += b,
+            _ => unreachable!("sum input and policy accumulator dtypes must agree"),
+        }
+    }
+}
+
+fn read_sum_value(ptr: *const u8, dtype: DType, _itemsize: usize) -> SumAccumulator {
+    use mohu_dtype::DType::*;
+    match dtype {
+        Bool => SumAccumulator::I64(unsafe { *ptr as i64 }),
+        I8 => SumAccumulator::I64(unsafe { ptr.cast::<i8>().read_unaligned() as i64 }),
+        I16 => SumAccumulator::I64(unsafe { ptr.cast::<i16>().read_unaligned() as i64 }),
+        I32 => SumAccumulator::I64(unsafe { ptr.cast::<i32>().read_unaligned() as i64 }),
+        I64 => SumAccumulator::I64(unsafe { ptr.cast::<i64>().read_unaligned() }),
+        U8 => SumAccumulator::U64(unsafe { *ptr as u64 }),
+        U16 => SumAccumulator::U64(unsafe { ptr.cast::<u16>().read_unaligned() as u64 }),
+        U32 => SumAccumulator::U64(unsafe { ptr.cast::<u32>().read_unaligned() as u64 }),
+        U64 => SumAccumulator::U64(unsafe { ptr.cast::<u64>().read_unaligned() }),
+        F16 => SumAccumulator::F32(
+            half::f16::from_bits(unsafe { ptr.cast::<u16>().read_unaligned() }).to_f32(),
+        ),
+        BF16 => SumAccumulator::F32(
+            half::bf16::from_bits(unsafe { ptr.cast::<u16>().read_unaligned() }).to_f32(),
+        ),
+        F32 => SumAccumulator::F32(unsafe { ptr.cast::<f32>().read_unaligned() }),
+        F64 => SumAccumulator::F64(unsafe { ptr.cast::<f64>().read_unaligned() }),
+        C64 => {
+            SumAccumulator::C64(unsafe { ptr.cast::<num_complex::Complex<f32>>().read_unaligned() })
+        },
+        C128 => SumAccumulator::C128(unsafe {
+            ptr.cast::<num_complex::Complex<f64>>().read_unaligned()
+        }),
+    }
+}
+
+fn write_sum_value(ptr: *mut u8, dtype: DType, value: SumAccumulator) {
+    match (dtype, value) {
+        (DType::I64, SumAccumulator::I64(v)) => unsafe { ptr.cast::<i64>().write_unaligned(v) },
+        (DType::U64, SumAccumulator::U64(v)) => unsafe { ptr.cast::<u64>().write_unaligned(v) },
+        (DType::F16, SumAccumulator::F32(v)) => unsafe {
+            ptr.cast::<u16>()
+                .write_unaligned(half::f16::from_f32(v).to_bits())
+        },
+        (DType::BF16, SumAccumulator::F32(v)) => unsafe {
+            ptr.cast::<u16>()
+                .write_unaligned(half::bf16::from_f32(v).to_bits())
+        },
+        (DType::F32, SumAccumulator::F32(v)) => unsafe { ptr.cast::<f32>().write_unaligned(v) },
+        (DType::F64, SumAccumulator::F64(v)) => unsafe { ptr.cast::<f64>().write_unaligned(v) },
+        (DType::C64, SumAccumulator::C64(v)) => unsafe {
+            ptr.cast::<num_complex::Complex<f32>>().write_unaligned(v)
+        },
+        (DType::C128, SumAccumulator::C128(v)) => unsafe {
+            ptr.cast::<num_complex::Complex<f64>>().write_unaligned(v)
+        },
+        _ => unreachable!("sum output and accumulator dtypes must agree"),
+    }
 }
 
 /// Reads a single element at `ptr` (of the given dtype) and casts to f64.

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -519,3 +519,108 @@ fn dlpack_rejects_negative_ndim_before_pointer_reads() {
         deleter(managed);
     }
 }
+
+#[test]
+fn sum_axis_dtype_and_values_follow_policy() {
+    let bools = Buffer::from_vec(vec![true, false, true]).unwrap();
+    let sum = bools.sum_axis(0, false).unwrap();
+    assert_eq!(sum.dtype(), DType::I64);
+    assert_eq!(sum.as_slice::<i64>().unwrap(), &[2]);
+
+    let signed = Buffer::from_vec(vec![1_i32, 2, 3, 4])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let sum = signed.sum_axis(0, true).unwrap();
+    assert_eq!(sum.dtype(), DType::I64);
+    assert_eq!(sum.shape(), &[1, 2]);
+    assert_eq!(sum.as_slice::<i64>().unwrap(), &[4, 6]);
+
+    let unsigned = Buffer::from_vec(vec![1_u32, 2, 3, 4])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let sum = unsigned.sum_axis(1, false).unwrap();
+    assert_eq!(sum.dtype(), DType::U64);
+    assert_eq!(sum.as_slice::<u64>().unwrap(), &[3, 7]);
+
+    let signed_overflow = Buffer::from_vec(vec![i64::MAX, 1])
+        .unwrap()
+        .sum_axis(0, false)
+        .unwrap();
+    assert_eq!(signed_overflow.as_slice::<i64>().unwrap(), &[i64::MIN]);
+    let unsigned_overflow = Buffer::from_vec(vec![u64::MAX, 1])
+        .unwrap()
+        .sum_axis(0, false)
+        .unwrap();
+    assert_eq!(unsigned_overflow.as_slice::<u64>().unwrap(), &[0]);
+}
+
+#[test]
+fn sum_axis_preserves_float_and_complex_output_dtypes() {
+    let f16 = Buffer::from_vec(vec![half::f16::from_f32(1.25), half::f16::from_f32(2.5)]).unwrap();
+    let sum = f16.sum_axis(0, false).unwrap();
+    assert_eq!(sum.dtype(), DType::F16);
+    assert!((sum.as_slice::<half::f16>().unwrap()[0].to_f32() - 3.75).abs() < 0.01);
+
+    let bf16 =
+        Buffer::from_vec(vec![half::bf16::from_f32(1.25), half::bf16::from_f32(2.5)]).unwrap();
+    let sum = bf16.sum_axis(0, false).unwrap();
+    assert_eq!(sum.dtype(), DType::BF16);
+    assert!((sum.as_slice::<half::bf16>().unwrap()[0].to_f32() - 3.75).abs() < 0.02);
+
+    let f32s = Buffer::from_vec(vec![1.25_f32, 2.5])
+        .unwrap()
+        .sum_axis(0, false)
+        .unwrap();
+    assert_eq!(f32s.dtype(), DType::F32);
+    assert!((f32s.as_slice::<f32>().unwrap()[0] - 3.75).abs() < 1e-6);
+    let f64s = Buffer::from_vec(vec![1.25_f64, 2.5])
+        .unwrap()
+        .sum_axis(0, false)
+        .unwrap();
+    assert_eq!(f64s.dtype(), DType::F64);
+    assert!((f64s.as_slice::<f64>().unwrap()[0] - 3.75).abs() < 1e-12);
+
+    let c64s = Buffer::from_vec(vec![
+        num_complex::Complex::new(1.0_f32, 2.0),
+        num_complex::Complex::new(3.0, 4.0),
+    ])
+    .unwrap()
+    .sum_axis(0, false)
+    .unwrap();
+    assert_eq!(c64s.dtype(), DType::C64);
+    assert_eq!(
+        c64s.as_slice::<num_complex::Complex<f32>>().unwrap(),
+        &[num_complex::Complex::new(4.0, 6.0)]
+    );
+    let c128s = Buffer::from_vec(vec![
+        num_complex::Complex::new(1.0_f64, 2.0),
+        num_complex::Complex::new(3.0, 4.0),
+    ])
+    .unwrap()
+    .sum_axis(0, false)
+    .unwrap();
+    assert_eq!(c128s.dtype(), DType::C128);
+    assert_eq!(
+        c128s.as_slice::<num_complex::Complex<f64>>().unwrap(),
+        &[num_complex::Complex::new(4.0, 6.0)]
+    );
+}
+
+#[test]
+fn sum_axis_handles_strided_and_empty_inputs() {
+    let transposed = Buffer::from_vec(vec![1_i32, 2, 3, 4, 5, 6])
+        .unwrap()
+        .reshape(&[2, 3])
+        .unwrap()
+        .transpose();
+    let sum = transposed.sum_axis(1, false).unwrap();
+    assert_eq!(sum.as_slice::<i64>().unwrap(), &[5, 7, 9]);
+
+    let empty = Buffer::zeros(DType::I32, &[2, 0]).unwrap();
+    let sum = empty.sum_axis(1, false).unwrap();
+    assert_eq!(sum.dtype(), DType::I64);
+    assert_eq!(sum.shape(), &[2]);
+    assert_eq!(sum.as_slice::<i64>().unwrap(), &[0, 0]);
+}


### PR DESCRIPTION
Implements the approved #34 reduction contract in canonical Buffer::sum_axis: explicit output/accumulator policy, wrapping fixed-width integer accumulation, F32 accumulation for F16/BF16, and full C64/C128 preservation. Adds regression coverage for all dtype families, overflow, keepdims, empty axes, and transposed layouts.