### PR TITLE
fix(buffer): enforce allclose contract

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -1763,12 +1763,28 @@ impl Buffer {
 
     // ─── Approximate equality ─────────────────────────────────────────────────
 
-    /// Returns `true` if all elements satisfy `|a - b| <= atol + rtol * |b|`.
+    /// Returns `true` if same-shaped float elements satisfy `|a - b| <= atol + rtol * |b|`.
     ///
-    /// NaN == NaN for this comparison (unlike IEEE 754).
+    /// NaN in either input returns `false`; same-sign infinities compare equal.
+    /// Integer and complex inputs return `MohuError::DomainError`.
     pub fn allclose(&self, other: &Buffer, rtol: f64, atol: f64) -> MohuResult<bool> {
+        if !self.dtype().is_float() {
+            return Err(MohuError::domain(
+                "allclose",
+                format!("unsupported dtype {:?}", self.dtype()),
+            ));
+        }
+        if !other.dtype().is_float() {
+            return Err(MohuError::domain(
+                "allclose",
+                format!("unsupported dtype {:?}", other.dtype()),
+            ));
+        }
         if self.shape() != other.shape() {
-            return Ok(false);
+            return Err(MohuError::ShapeMismatch {
+                expected: self.shape().to_vec(),
+                got: other.shape().to_vec(),
+            });
         }
         let a = self.cast(DType::F64, CastMode::Unsafe)?;
         let b = other.cast(DType::F64, CastMode::Unsafe)?;
@@ -1776,7 +1792,10 @@ impl Buffer {
         let bs = b.as_slice::<f64>()?;
         use rayon::prelude::*;
         Ok(as_.par_iter().zip(bs.par_iter()).all(|(a, b)| {
-            if a.is_nan() && b.is_nan() {
+            if a.is_nan() || b.is_nan() {
+                return false;
+            }
+            if a == b {
                 return true;
             }
             (a - b).abs() <= atol + rtol * b.abs()

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -624,3 +624,44 @@ fn sum_axis_handles_strided_and_empty_inputs() {
     assert_eq!(sum.shape(), &[2]);
     assert_eq!(sum.as_slice::<i64>().unwrap(), &[0, 0]);
 }
+#[test]
+fn allclose_contract_covers_values_nan_infinities_and_dtypes() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0, f64::INFINITY, f64::NEG_INFINITY]).unwrap();
+    let b = Buffer::from_slice(&[1.0_f64, 2.000001, f64::INFINITY, f64::NEG_INFINITY]).unwrap();
+    assert!(a.allclose(&b, 1e-5, 1e-8).unwrap());
+    let far = Buffer::from_slice(&[1.0_f64, 2.1, f64::INFINITY, f64::NEG_INFINITY]).unwrap();
+    assert!(!a.allclose(&far, 1e-5, 1e-8).unwrap());
+    let nan = Buffer::from_slice(&[f64::NAN, 2.0, f64::INFINITY, f64::NEG_INFINITY]).unwrap();
+    assert!(!a.allclose(&nan, 1e-5, 1e-8).unwrap());
+    assert!(!nan.allclose(&nan, 1e-5, 1e-8).unwrap());
+
+    let f32_a = Buffer::from_slice(&[1.0_f32, 2.0]).unwrap();
+    let f32_b = Buffer::from_slice(&[1.0_f32, 2.000001]).unwrap();
+    assert!(f32_a.allclose(&f32_b, 1e-5, 1e-8).unwrap());
+    let f16_a = Buffer::from_slice(&[half::f16::from_f32(1.0)]).unwrap();
+    let f16_b = Buffer::from_slice(&[half::f16::from_f32(1.0001)]).unwrap();
+    assert!(f16_a.allclose(&f16_b, 1e-3, 1e-8).unwrap());
+    let bf16_a = Buffer::from_slice(&[half::bf16::from_f32(1.0)]).unwrap();
+    let bf16_b = Buffer::from_slice(&[half::bf16::from_f32(1.001)]).unwrap();
+    assert!(bf16_a.allclose(&bf16_b, 1e-2, 1e-8).unwrap());
+}
+
+#[test]
+fn allclose_contract_rejects_shape_and_non_float_inputs() {
+    let a = Buffer::from_slice(&[1.0_f64, 2.0]).unwrap();
+    let shape_mismatch = Buffer::from_slice(&[1.0_f64]).unwrap();
+    assert!(matches!(
+        a.allclose(&shape_mismatch, 1e-5, 1e-8),
+        Err(mohu_error::MohuError::ShapeMismatch { .. })
+    ));
+    let integer = Buffer::from_slice(&[1_i32, 2]).unwrap();
+    assert!(matches!(
+        a.allclose(&integer, 1e-5, 1e-8),
+        Err(mohu_error::MohuError::DomainError { .. })
+    ));
+    let complex = Buffer::from_slice(&[num_complex::Complex::<f32>::new(1.0, 2.0)]).unwrap();
+    assert!(matches!(
+        complex.allclose(&complex, 1e-5, 1e-8),
+        Err(mohu_error::MohuError::DomainError { .. })
+    ));
+}


### PR DESCRIPTION
Fixes #145. Implements strict same-shape float-only allclose: ShapeMismatch on shape differences, DomainError for integer/complex inputs, NaN false, and same-sign infinities equal. Adds focused regression tests. Clean narrow replacement for the useful behavior in contaminated #163.