### PR TITLE
fix(buffer): return typed dimension errors

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -1158,7 +1158,10 @@ impl Buffer {
     /// Equivalent to `np.diag(v, k)` when `v` is 1-D.
     pub fn diag(v: &Buffer, k: i64) -> MohuResult<Self> {
         if v.ndim() != 1 {
-            return Err(MohuError::bug("Buffer::diag: input must be 1-D"));
+            return Err(MohuError::DimensionMismatch {
+                expected: 1,
+                got: v.ndim(),
+            });
         }
         let n = v.len();
         let size = if k >= 0 {
@@ -1194,7 +1197,10 @@ impl Buffer {
     /// Works for any 2-D buffer (contiguous or not).
     pub fn diagonal(&self, k: i64) -> MohuResult<Self> {
         if self.ndim() < 2 {
-            return Err(MohuError::bug("diagonal: requires at least 2 dimensions"));
+            return Err(MohuError::DimensionMismatch {
+                expected: 2,
+                got: self.ndim(),
+            });
         }
         let nd = self.ndim();
         let n = self.shape()[nd - 2];
@@ -1290,7 +1296,10 @@ impl Buffer {
     /// `k = 0` keeps the main diagonal; `k < 0` zeros more; `k > 0` keeps more.
     pub fn tril(&self, k: i64) -> MohuResult<Self> {
         if self.ndim() != 2 {
-            return Err(MohuError::bug("tril: requires exactly 2 dimensions"));
+            return Err(MohuError::DimensionMismatch {
+                expected: 2,
+                got: self.ndim(),
+            });
         }
         let out = self.to_contiguous()?;
         let (rows, cols) = (out.shape()[0], out.shape()[1]);
@@ -1316,7 +1325,10 @@ impl Buffer {
     /// Elements below diagonal `k` are zeroed.
     pub fn triu(&self, k: i64) -> MohuResult<Self> {
         if self.ndim() != 2 {
-            return Err(MohuError::bug("triu: requires exactly 2 dimensions"));
+            return Err(MohuError::DimensionMismatch {
+                expected: 2,
+                got: self.ndim(),
+            });
         }
         let out = self.to_contiguous()?;
         let (rows, cols) = (out.shape()[0], out.shape()[1]);

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -625,6 +625,40 @@ fn sum_axis_handles_strided_and_empty_inputs() {
     assert_eq!(sum.as_slice::<i64>().unwrap(), &[0, 0]);
 }
 #[test]
+fn diagonal_operations_report_dimension_mismatches() {
+    let one_d = Buffer::from_slice(&[1_i32, 2, 3]).unwrap();
+    let two_d = one_d.reshape(&[1, 3]).unwrap();
+    assert!(matches!(
+        Buffer::diag(&two_d, 0),
+        Err(MohuError::DimensionMismatch {
+            expected: 1,
+            got: 2
+        })
+    ));
+    assert!(matches!(
+        one_d.diagonal(0),
+        Err(MohuError::DimensionMismatch {
+            expected: 2,
+            got: 1
+        })
+    ));
+    assert!(matches!(
+        one_d.tril(0),
+        Err(MohuError::DimensionMismatch {
+            expected: 2,
+            got: 1
+        })
+    ));
+    assert!(matches!(
+        one_d.triu(0),
+        Err(MohuError::DimensionMismatch {
+            expected: 2,
+            got: 1
+        })
+    ));
+}
+
+#[test]
 fn allclose_contract_covers_values_nan_infinities_and_dtypes() {
     let a = Buffer::from_slice(&[1.0_f64, 2.0, f64::INFINITY, f64::NEG_INFINITY]).unwrap();
     let b = Buffer::from_slice(&[1.0_f64, 2.000001, f64::INFINITY, f64::NEG_INFINITY]).unwrap();


### PR DESCRIPTION
Extracts the focused correctness portion of #166. Diagonal and triangular operations now return `MohuError::DimensionMismatch` for invalid rank, with regression tests. Excludes historical CI, formatting, dtype, and unrelated changes from #166.\n\nRefs #142\nRefs #143\n\nOriginal contributor work reviewed from #166; this maintainer branch preserves the typed-error fix intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting for diagonal and triangular matrix operations.
  - Invalid input dimensions now return clear dimension-mismatch errors instead of generic errors.

- **Tests**
  - Added coverage confirming consistent dimension validation across supported matrix operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->