### PR TITLE
feat(buffer): add broadcast shape helper

### DIFF
--- a/crates/mohu-buffer/src/lib.rs
+++ b/crates/mohu-buffer/src/lib.rs
@@ -39,8 +39,9 @@ pub use ops::{
 pub use pool::{BufferPool, GLOBAL_POOL, PoolStats};
 
 pub use strides::{
-    NdIndexIter, ShapeVec, StrideVec, StridedByteIter, broadcast_strides, byte_offset, c_strides,
-    contiguous_nbytes, f_strides, ravel_multi_index, shape_size, unravel_index, validate_strides,
+    NdIndexIter, ShapeVec, StrideVec, StridedByteIter, broadcast_shapes, broadcast_strides,
+    byte_offset, c_strides, contiguous_nbytes, f_strides, ravel_multi_index, shape_size,
+    unravel_index, validate_strides,
 };
 
 pub use view::{BufferView, BufferViewMut};

--- a/crates/mohu-buffer/src/strides.rs
+++ b/crates/mohu-buffer/src/strides.rs
@@ -93,6 +93,44 @@ pub fn contiguous_nbytes(shape: &[usize], itemsize: usize) -> MohuResult<usize> 
         .ok_or(MohuError::ShapeOverflow { max: usize::MAX })
 }
 
+// ─── Broadcast shapes ────────────────────────────────────────────────────────
+
+/// Computes common shape for two arrays using right-aligned broadcasting.
+///
+/// Dimensions are compatible when equal or when either dimension is one.
+/// Zero-sized dimensions remain zero when paired with one; zero with any other
+/// dimension is incompatible.
+pub fn broadcast_shapes(a: &[usize], b: &[usize]) -> MohuResult<ShapeVec> {
+    let rank = a.len().max(b.len());
+    let a_offset = rank - a.len();
+    let b_offset = rank - b.len();
+    let mut shape = ShapeVec::with_capacity(rank);
+    for axis in 0..rank {
+        let adim = a
+            .get(axis.checked_sub(a_offset).unwrap_or(usize::MAX))
+            .copied()
+            .unwrap_or(1);
+        let bdim = b
+            .get(axis.checked_sub(b_offset).unwrap_or(usize::MAX))
+            .copied()
+            .unwrap_or(1);
+        let dim = if adim == bdim {
+            adim
+        } else if adim == 1 {
+            bdim
+        } else if bdim == 1 {
+            adim
+        } else {
+            return Err(MohuError::BroadcastError {
+                lhs: a.to_vec(),
+                rhs: b.to_vec(),
+            });
+        };
+        shape.push(dim);
+    }
+    Ok(shape)
+}
+
 // ─── Broadcast strides ────────────────────────────────────────────────────────
 
 /// Computes broadcast-compatible strides for a source shape/stride pair when

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -153,6 +153,56 @@ fn broadcast_scalar_to_matrix() {
 }
 
 #[test]
+fn broadcast_shapes_resolves_right_aligned_dimensions() {
+    assert_eq!(
+        mohu_buffer::broadcast_shapes(&[3], &[2, 3])
+            .unwrap()
+            .as_slice(),
+        &[2, 3]
+    );
+    assert_eq!(
+        mohu_buffer::broadcast_shapes(&[1, 1, 3], &[4, 5, 3])
+            .unwrap()
+            .as_slice(),
+        &[4, 5, 3]
+    );
+    assert_eq!(
+        mohu_buffer::broadcast_shapes(&[], &[2, 3])
+            .unwrap()
+            .as_slice(),
+        &[2, 3]
+    );
+    assert_eq!(
+        mohu_buffer::broadcast_shapes(&[], &[]).unwrap().as_slice(),
+        &[]
+    );
+}
+
+#[test]
+fn broadcast_shapes_rejects_incompatible_and_handles_empty_axes() {
+    assert!(matches!(
+        mohu_buffer::broadcast_shapes(&[2, 3], &[2, 4]),
+        Err(MohuError::BroadcastError { .. })
+    ));
+    assert!(matches!(
+        mohu_buffer::broadcast_shapes(&[0], &[2]),
+        Err(MohuError::BroadcastError { .. })
+    ));
+    assert_eq!(
+        mohu_buffer::broadcast_shapes(&[0], &[1])
+            .unwrap()
+            .as_slice(),
+        &[0]
+    );
+    assert_eq!(
+        mohu_buffer::broadcast_shapes(&[0], &[0])
+            .unwrap()
+            .as_slice(),
+        &[0]
+    );
+}
+
+#[test]
 fn broadcast_row_to_matrix() {
     let data = vec![1.0_f32, 2.0, 3.0];
     let buf = Buffer::from_slice(&data).unwrap().reshape(&[1, 3]).unwrap();

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -174,7 +174,7 @@ fn broadcast_shapes_resolves_right_aligned_dimensions() {
     );
     assert_eq!(
         mohu_buffer::broadcast_shapes(&[], &[]).unwrap().as_slice(),
-        &[]
+        &[] as &[usize]
     );
 }
 


### PR DESCRIPTION
Clean extraction of #167 intent. Adds public right-aligned `broadcast_shapes` resolution, preserves the existing `BroadcastError` contract, handles scalar and zero-dimension cases, and adds focused tests. Excludes historical formatting, CI, and unrelated buffer changes.\n\nRefs #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public shape broadcasting support using right-aligned, NumPy-style rules.
  * Compatible dimensions now resolve to a common shape, including supported zero-sized dimensions.
  * Incompatible shapes return a clear broadcasting error.

* **Tests**
  * Added coverage for compatible, empty, zero-sized, and incompatible shape combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->