### PR TITLE
feat(mohu-dtype): implement Default for DType returning F64

### DIFF
--- a/crates/mohu-dtype/src/dtype.rs
+++ b/crates/mohu-dtype/src/dtype.rs
@@ -597,7 +597,21 @@ impl<'de> serde::Deserialize<'de> for DType {
 }
 
 // ─── compile-time invariant checks ───────────────────────────────────────────
+// ─── Default ─────────────────────────────────────────────────────────────────
 
+impl Default for DType {
+    /// Returns [`DType::F64`] as the default dtype, matching NumPy's
+    /// default floating-point type (`float64`).
+    ///
+    /// # Example
+    /// ```
+    /// use mohu_dtype::DType;
+    /// assert_eq!(DType::default(), DType::F64);
+    /// ```
+    fn default() -> Self {
+        Self::F64
+    }
+}
 const _: () = {
     assert!(ALL_DTYPES.len() == DTYPE_COUNT);
     assert!(DType::Bool as u8 == 0);

--- a/crates/mohu-dtype/tests/dtype_tests.rs
+++ b/crates/mohu-dtype/tests/dtype_tests.rs
@@ -1,0 +1,15 @@
+use mohu_dtype::DType;
+
+#[test]
+fn default_dtype_is_f64() {
+    assert_eq!(DType::default(), DType::F64);
+}
+
+#[test]
+fn struct_deriving_default_uses_f64() {
+    #[derive(Default)]
+    struct Config {
+        dtype: DType,
+    }
+    assert_eq!(Config::default().dtype, DType::F64);
+}


### PR DESCRIPTION
Clean maintainer integration of #179. Preserves the contributor implementation and tests; historical branch was refreshed against current main without force-pushing it. Closes #128.