### PR TITLE
feat(mohu-buffer): default Order to C

### DIFF
--- a/crates/mohu-buffer/src/layout.rs
+++ b/crates/mohu-buffer/src/layout.rs
@@ -22,19 +22,14 @@ use crate::strides::{
 // ─── Order ────────────────────────────────────────────────────────────────────
 
 /// Memory order preference for new contiguous allocations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Order {
     /// Row-major (C) order — the last axis varies fastest in memory.
+    #[default]
     C,
     /// Column-major (Fortran) order — the first axis varies fastest.
     F,
 }
-impl Default for Order {
-    fn default() -> Self {
-        Self::C
-    }
-}
-
 
 // ─── SliceArg ────────────────────────────────────────────────────────────────
 

--- a/crates/mohu-buffer/src/layout.rs
+++ b/crates/mohu-buffer/src/layout.rs
@@ -29,6 +29,12 @@ pub enum Order {
     /// Column-major (Fortran) order — the first axis varies fastest.
     F,
 }
+impl Default for Order {
+    fn default() -> Self {
+        Self::C
+    }
+}
+
 
 // ─── SliceArg ────────────────────────────────────────────────────────────────
 

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -9,6 +9,11 @@ use mohu_buffer::{
 use mohu_dtype::{DType, promote::CastMode};
 use mohu_error::MohuError;
 
+#[test]
+fn default_order_is_c() {
+    assert_eq!(Order::default(), Order::C);
+}
+
 // ── 1. Allocation ─────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Clean narrow integration for #38. Adds the established row-major default and a regression test. Closes #38.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Row-major (`C`) ordering is now used when no ordering is explicitly specified.

* **Tests**
  * Added coverage confirming that the default ordering is row-major.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->