### PR TITLE
docs: add local CI make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,22 @@
-.PHONY: build release test lint fmt fmt-check check clean bench deny changelog contrib-guide
+.PHONY: build release test lint fmt fmt-check check ci clean bench deny changelog size contrib-guide help
+
+help:
+	@echo "Available targets:"
+	@echo "  build          Build the workspace"
+	@echo "  release        Build the workspace in release mode"
+	@echo "  test           Run workspace tests"
+	@echo "  lint           Run workspace clippy"
+	@echo "  fmt            Format all Rust code"
+	@echo "  fmt-check      Check Rust formatting"
+	@echo "  check          Run formatting, lint, and tests"
+	@echo "  ci             Run the local CI validation loop"
+	@echo "  clean          Remove build artifacts"
+	@echo "  bench          Run benchmarks"
+	@echo "  deny           Run cargo-deny"
+	@echo "  changelog      Regenerate the changelog"
+	@echo "  size           Show release library size"
+	@echo "  contrib-guide  Print contributor references"
+	@echo "Windows users: run make through WSL or Git Bash."
 
 build:
 	cargo build --workspace
@@ -19,6 +37,8 @@ fmt-check:
 	cargo fmt --all -- --check
 
 check: fmt-check lint test
+
+ci: check
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ cargo build --workspace
 cargo test --workspace
 ```
 
+For the canonical local validation loop, run:
+
+```bash
+make ci
+```
+
 Today the usable surface is `mohu-buffer` — the strided, dtype-tagged, reference-counted
 buffer that every future `NdArray` sits on top of:
 


### PR DESCRIPTION
Implements the useful portion of #130. Adds a concise help target, a non-mutating `ci` alias for the existing `check` target, and documents `make ci` in the README. No fuzz target is added because the repository has no supported fuzz harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `make help` command that lists available project commands and includes Windows usage guidance.
  - Added a `make ci` command for running the standard validation checks.

- **Documentation**
  - Updated the Quickstart guide with the recommended `make ci` validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->