### PR TITLE
feat(index): add safe advanced indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,9 +720,11 @@ dependencies = [
 name = "mohu-index"
 version = "0.1.0"
 dependencies = [
+ "half",
  "mohu-buffer",
  "mohu-dtype",
  "mohu-error",
+ "num-complex",
  "rayon",
  "smallvec",
 ]

--- a/crates/mohu-index/Cargo.toml
+++ b/crates/mohu-index/Cargo.toml
@@ -17,7 +17,9 @@ mohu-dtype.workspace  = true
 mohu-buffer.workspace = true
 rayon.workspace       = true
 smallvec.workspace    = true
+half.workspace        = true
+num-complex.workspace = true
 
 
 [package.metadata.cargo-machete]
-ignored = ["mohu-buffer", "mohu-dtype", "rayon", "smallvec"]
+ignored = ["half", "mohu-buffer", "mohu-dtype", "num-complex", "rayon", "smallvec"]

--- a/crates/mohu-index/src/boolean.rs
+++ b/crates/mohu-index/src/boolean.rs
@@ -1,1 +1,41 @@
-// boolean — implementation pending
+//! Boolean mask indexing.
+use mohu_buffer::{Buffer, NdIndexIter, Order};
+use mohu_dtype::{dispatch_dtype, dtype::DType};
+use mohu_error::{MohuError, MohuResult};
+
+/// Return a new one-dimensional buffer containing values selected by `mask`.
+pub fn index_bool(src: &Buffer, mask: &Buffer) -> MohuResult<Buffer> {
+    if mask.dtype() != DType::Bool {
+        return Err(MohuError::DomainError {
+            op: "index_bool",
+            reason: format!("mask must have Bool dtype, got {}", mask.dtype()),
+        });
+    }
+    if mask.shape() != src.shape() {
+        return Err(MohuError::ShapeMismatch {
+            expected: src.shape().to_vec(),
+            got: mask.shape().to_vec(),
+        });
+    }
+    let mut count = 0;
+    for idx in NdIndexIter::new(src.shape()) {
+        if mask.get::<bool>(&idx)? {
+            count += 1;
+        }
+    }
+    let mut output = Buffer::alloc(src.dtype(), &[count], Order::C)?;
+    macro_rules! copy {
+        ($ty:ty) => {{
+            let mut pos = 0;
+            for idx in NdIndexIter::new(src.shape()) {
+                if mask.get::<bool>(&idx)? {
+                    let value = src.get::<$ty>(&idx)?;
+                    output.set::<$ty>(&[pos], value)?;
+                    pos += 1;
+                }
+            }
+            Ok(output)
+        }};
+    }
+    dispatch_dtype!(src.dtype(), copy)
+}

--- a/crates/mohu-index/src/lib.rs
+++ b/crates/mohu-index/src/lib.rs
@@ -29,4 +29,7 @@ pub mod slice;
 pub mod take;
 pub mod where_op;
 
+pub use boolean::index_bool;
+pub use take::index_take;
+
 pub use mohu_error::{MohuError, MohuResult};

--- a/crates/mohu-index/src/take.rs
+++ b/crates/mohu-index/src/take.rs
@@ -1,1 +1,60 @@
-// take — implementation pending
+//! Integer-array take indexing.
+use mohu_buffer::{Buffer, NdIndexIter, Order};
+use mohu_dtype::{dispatch_dtype, dtype::DType};
+use mohu_error::{MohuError, MohuResult};
+
+/// Return an owning buffer selected along `axis` by non-negative I64 indices.
+pub fn index_take(src: &Buffer, indices: &Buffer, axis: usize) -> MohuResult<Buffer> {
+    if indices.dtype() != DType::I64 {
+        return Err(MohuError::DomainError {
+            op: "index_take",
+            reason: format!("indices must have I64 dtype, got {}", indices.dtype()),
+        });
+    }
+    if axis >= src.ndim() {
+        return Err(MohuError::AxisOutOfRange {
+            axis: axis as i64,
+            ndim: src.ndim(),
+            valid: if src.ndim() == 0 {
+                "none".into()
+            } else {
+                format!("0..{}", src.ndim())
+            },
+        });
+    }
+    let axis_size = src.shape()[axis];
+    let mut normalized = Vec::with_capacity(indices.len());
+    for coord in NdIndexIter::new(indices.shape()) {
+        let index = indices.get::<i64>(&coord)?;
+        if index < 0 || (index as u128) >= axis_size as u128 {
+            return Err(MohuError::IndexOutOfBounds {
+                index,
+                axis,
+                size: axis_size,
+            });
+        }
+        normalized.push(index as usize);
+    }
+    let mut out_shape = Vec::with_capacity(src.ndim() - 1 + indices.ndim());
+    out_shape.extend_from_slice(&src.shape()[..axis]);
+    out_shape.extend_from_slice(indices.shape());
+    out_shape.extend_from_slice(&src.shape()[axis + 1..]);
+    let mut output = Buffer::alloc(src.dtype(), &out_shape, Order::C)?;
+    macro_rules! copy {
+        ($ty:ty) => {{
+            for out_coord in NdIndexIter::new(&out_shape) {
+                let idx_coord = &out_coord[axis..axis + indices.ndim()];
+                let selected = indices.get::<i64>(idx_coord)? as usize;
+                let mut src_coord = Vec::with_capacity(src.ndim());
+                src_coord.extend_from_slice(&out_coord[..axis]);
+                src_coord.push(selected);
+                src_coord.extend_from_slice(&out_coord[axis + indices.ndim()..]);
+                let value = src.get::<$ty>(&src_coord)?;
+                output.set::<$ty>(&out_coord, value)?;
+            }
+            Ok(output)
+        }};
+    }
+    let _ = normalized;
+    dispatch_dtype!(src.dtype(), copy)
+}

--- a/crates/mohu-index/tests/indexing.rs
+++ b/crates/mohu-index/tests/indexing.rs
@@ -1,0 +1,81 @@
+use mohu_buffer::Buffer;
+use mohu_dtype::dtype::DType;
+use mohu_error::MohuError;
+use mohu_index::{index_bool, index_take};
+
+fn shaped<T: mohu_dtype::scalar::Scalar>(v: &[T], shape: &[usize]) -> Buffer {
+    Buffer::from_slice(v).unwrap().reshape(shape).unwrap()
+}
+
+#[test]
+fn bool_index_selects_owning_values() {
+    let src = shaped(&[1i32, 2, 3, 4], &[2, 2]);
+    let mask = shaped(&[true, false, false, true], &[2, 2]);
+    let out = index_bool(&src, &mask).unwrap();
+    assert_eq!(out.shape(), &[2]);
+    assert_eq!(out.dtype(), DType::I32);
+    assert_eq!(out.to_vec::<i32>().unwrap(), vec![1, 4]);
+    assert!(out.is_writeable());
+}
+
+#[test]
+fn bool_index_errors() {
+    let src = Buffer::from_slice(&[1i32, 2]).unwrap();
+    let wrong = Buffer::from_slice(&[1i32, 0]).unwrap();
+    assert!(matches!(
+        index_bool(&src, &wrong),
+        Err(MohuError::DomainError { .. })
+    ));
+    let mask = Buffer::from_slice(&[true]).unwrap();
+    assert!(matches!(
+        index_bool(&src, &mask),
+        Err(MohuError::ShapeMismatch { .. })
+    ));
+}
+
+#[test]
+fn take_supports_axis_and_nd_indices() {
+    let src = shaped(&[10i32, 11, 12, 20, 21, 22], &[2, 3]);
+    let rows = Buffer::from_slice(&[1i64, 0]).unwrap();
+    let out = index_take(&src, &rows, 0).unwrap();
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(out.to_vec::<i32>().unwrap(), vec![20, 21, 22, 10, 11, 12]);
+    let cols = shaped(&[2i64, 0, 1, 1], &[2, 2]);
+    let out = index_take(&src, &cols, 1).unwrap();
+    assert_eq!(out.shape(), &[2, 2, 2]);
+    assert_eq!(
+        out.to_vec::<i32>().unwrap(),
+        vec![12, 10, 11, 11, 22, 20, 21, 21]
+    );
+}
+
+#[test]
+fn take_rejects_negative_oob_and_bad_axis() {
+    let src = Buffer::from_slice(&[1i32, 2, 3]).unwrap();
+    for value in [-1i64, 3] {
+        let idx = Buffer::from_slice(&[value]).unwrap();
+        assert!(
+            matches!(index_take(&src,&idx,0),Err(MohuError::IndexOutOfBounds{index,axis:0,size:3}) if index==value)
+        );
+    }
+    let idx = Buffer::from_slice(&[0i64]).unwrap();
+    assert!(matches!(
+        index_take(&src, &idx, 1),
+        Err(MohuError::AxisOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn take_empty_indices_substitute_shape() {
+    let src = Buffer::from_slice::<i32>(&[])
+        .unwrap()
+        .reshape(&[0, 3])
+        .unwrap();
+    let idx = Buffer::from_slice::<i64>(&[])
+        .unwrap()
+        .reshape(&[0, 2])
+        .unwrap();
+    let out = index_take(&src, &idx, 1).unwrap();
+    assert_eq!(out.shape(), &[0, 0, 2]);
+    assert_eq!(out.len(), 0);
+}


### PR DESCRIPTION
Canonical integration for #149. Adds safe boolean mask and integer-array take indexing with owning outputs, multidimensional index-buffer shape substitution, explicit dtype/axis/OOB errors, and no negative-index wrapping in v1. Reconciles prior work from #182 and the indexing portion of #263 against the current contract. The implementation uses existing Buffer safe get/set APIs and dtype dispatch; no unsafe code is added.