### PR TITLE
feat(random): add seeded generator

### DIFF
--- a/crates/mohu-random/src/lib.rs
+++ b/crates/mohu-random/src/lib.rs
@@ -1,8 +1,9 @@
 /// PRNG engines and statistical distributions for mohu.
 ///
-/// Equivalent to `numpy.random` — but faster, thread-safe, and reproducible
-/// across platforms.  Every generator uses a splittable / jumpable PRNG so
-/// that parallel workers each get an independent, non-overlapping stream.
+/// PRNG engines and statistical distributions for mohu.
+///
+/// The seeded convenience generator is deterministic for the selected engine
+/// implementation; it does not promise stability across engine changes.
 ///
 /// # Generators
 ///
@@ -29,8 +30,7 @@
 /// let data = rng.standard_normal::<f64>(&[1000]);
 /// ```
 ///
-/// All generators implement `Seed` — the same seed always produces the
-/// same sequence regardless of CPU count or mohu version within a major.
+/// Low-level engines expose explicit seeding and stateful streams.
 pub mod continuous;
 pub mod discrete;
 pub mod entropy;
@@ -39,5 +39,97 @@ pub mod multivariate;
 pub mod permutation;
 pub mod seeding;
 
+use mohu_buffer::{buffer::Buffer, layout::Order};
+use mohu_dtype::dtype::DType;
+
 pub use generator::{Generator, Pcg64, Philox4x64};
 pub use mohu_error::{MohuError, MohuResult};
+
+/// Stateful convenience generator backed by the default `Pcg64` engine.
+///
+/// Two instances created with the same seed produce the same sequence for the
+/// same calls with this engine implementation.
+pub struct Rng {
+    pcg: Pcg64,
+}
+
+impl Rng {
+    /// Creates a generator with a deterministic seed.
+    pub fn new(seed: u64) -> Self {
+        Self {
+            pcg: Pcg64::seed(seed),
+        }
+    }
+
+    fn rand_f64(&mut self) -> f64 {
+        let bits = self.pcg.next_u64() >> 11;
+        bits as f64 * (1.0 / 9_007_199_254_740_992.0)
+    }
+
+    /// Generates an F64 buffer with values in `[low, high)`.
+    pub fn uniform(&mut self, shape: &[usize], low: f64, high: f64) -> MohuResult<Buffer> {
+        if !low.is_finite() || !high.is_finite() || high <= low || !(high - low).is_finite() {
+            return Err(MohuError::DomainError {
+                op: "uniform",
+                reason: "finite bounds required with high > low".into(),
+            });
+        }
+        let mut output = Buffer::alloc(DType::F64, shape, Order::C)?;
+        for value in output.as_mut_slice::<f64>()? {
+            *value = low + (high - low) * self.rand_f64();
+        }
+        Ok(output)
+    }
+
+    /// Generates an F64 buffer using the Box-Muller normal transform.
+    pub fn normal(&mut self, shape: &[usize], mean: f64, std: f64) -> MohuResult<Buffer> {
+        if !mean.is_finite() || !std.is_finite() || std <= 0.0 {
+            return Err(MohuError::DomainError {
+                op: "normal",
+                reason: "finite mean and positive finite std required".into(),
+            });
+        }
+        let mut output = Buffer::alloc(DType::F64, shape, Order::C)?;
+        let values = output.as_mut_slice::<f64>()?;
+        let mut i = 0;
+        while i < values.len() {
+            let mut u1 = self.rand_f64();
+            while u1 == 0.0 {
+                u1 = self.rand_f64();
+            }
+            let u2 = self.rand_f64();
+            let magnitude = (-2.0 * u1.ln()).sqrt();
+            let theta = 2.0 * std::f64::consts::PI * u2;
+            values[i] = mean + std * magnitude * theta.cos();
+            if i + 1 < values.len() {
+                values[i + 1] = mean + std * magnitude * theta.sin();
+            }
+            i += 2;
+        }
+        Ok(output)
+    }
+
+    /// Generates an I64 buffer with values in `[low, high)` without modulo bias.
+    pub fn integers(&mut self, shape: &[usize], low: i64, high: i64) -> MohuResult<Buffer> {
+        if high <= low {
+            return Err(MohuError::DomainError {
+                op: "integers",
+                reason: "high must be greater than low".into(),
+            });
+        }
+        let span = (high as i128 - low as i128) as u128;
+        let domain = 1u128 << 64;
+        let limit = domain - domain % span;
+        let mut output = Buffer::alloc(DType::I64, shape, Order::C)?;
+        for value in output.as_mut_slice::<i64>()? {
+            let draw = loop {
+                let draw = self.pcg.next_u64() as u128;
+                if draw < limit {
+                    break draw;
+                }
+            };
+            *value = (low as i128 + (draw % span) as i128) as i64;
+        }
+        Ok(output)
+    }
+}

--- a/crates/mohu-random/tests/rng.rs
+++ b/crates/mohu-random/tests/rng.rs
@@ -1,0 +1,103 @@
+use mohu_dtype::dtype::DType;
+use mohu_random::Rng;
+
+#[test]
+fn seeded_streams_reproduce_all_distributions() {
+    let mut a = Rng::new(42);
+    let mut b = Rng::new(42);
+    assert_eq!(
+        a.uniform(&[8], -2.0, 3.0).unwrap().to_vec::<f64>().unwrap(),
+        b.uniform(&[8], -2.0, 3.0).unwrap().to_vec::<f64>().unwrap()
+    );
+    assert_eq!(
+        a.normal(&[8], 1.0, 2.0).unwrap().to_vec::<f64>().unwrap(),
+        b.normal(&[8], 1.0, 2.0).unwrap().to_vec::<f64>().unwrap()
+    );
+    assert_eq!(
+        a.integers(&[8], -10, 10).unwrap().to_vec::<i64>().unwrap(),
+        b.integers(&[8], -10, 10).unwrap().to_vec::<i64>().unwrap()
+    );
+}
+
+#[test]
+fn uniform_and_normal_validate_parameters() {
+    let mut rng = Rng::new(1);
+    assert!(rng.uniform(&[1], 1.0, 1.0).is_err());
+    assert!(rng.uniform(&[1], f64::NEG_INFINITY, 1.0).is_err());
+    assert!(rng.normal(&[1], 0.0, 0.0).is_err());
+    assert!(rng.normal(&[1], 0.0, f64::INFINITY).is_err());
+}
+
+#[test]
+fn normal_has_no_non_finite_values() {
+    let mut rng = Rng::new(7);
+    let values = rng
+        .normal(&[1000], 0.0, 1.0)
+        .unwrap()
+        .to_vec::<f64>()
+        .unwrap();
+    assert!(values.iter().all(|x| x.is_finite()));
+}
+
+#[test]
+fn integers_cover_signed_wide_ranges_without_overflow() {
+    let mut rng = Rng::new(9);
+    let values = rng.integers(&[1000], i64::MIN, i64::MAX).unwrap();
+    assert_eq!(values.dtype(), DType::I64);
+    assert!(
+        values
+            .to_vec::<i64>()
+            .unwrap()
+            .iter()
+            .all(|&x| (i64::MIN..i64::MAX).contains(&x))
+    );
+    assert!(rng.integers(&[1], i64::MAX, i64::MIN).is_err());
+}
+
+#[test]
+fn zero_sized_shapes_do_not_consume_or_fail() {
+    let mut a = Rng::new(5);
+    let mut b = Rng::new(5);
+    assert_eq!(a.uniform(&[0, 3], 0.0, 1.0).unwrap().len(), 0);
+    assert_eq!(
+        a.uniform(&[1], 0.0, 1.0).unwrap().to_vec::<f64>().unwrap(),
+        b.uniform(&[1], 0.0, 1.0).unwrap().to_vec::<f64>().unwrap()
+    );
+}
+
+#[test]
+fn uniform_is_half_open_and_different_seeds_diverge() {
+    let mut a = Rng::new(1);
+    let mut b = Rng::new(2);
+    let values = a
+        .uniform(&[1000], -2.0, 3.0)
+        .unwrap()
+        .to_vec::<f64>()
+        .unwrap();
+    assert!(values.iter().all(|&x| (-2.0..3.0).contains(&x)));
+    assert_ne!(
+        values,
+        b.uniform(&[1000], -2.0, 3.0)
+            .unwrap()
+            .to_vec::<f64>()
+            .unwrap()
+    );
+}
+
+#[test]
+fn fixed_seed_normal_moments_are_reasonable() {
+    let mut rng = Rng::new(123);
+    let values = rng
+        .normal(&[10_000], 2.0, 3.0)
+        .unwrap()
+        .to_vec::<f64>()
+        .unwrap();
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
+    let variance = values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / values.len() as f64;
+    assert!((mean - 2.0).abs() < 0.1, "mean={mean}");
+    assert!(
+        (variance.sqrt() - 3.0).abs() < 0.1,
+        "std={}",
+        variance.sqrt()
+    );
+}


### PR DESCRIPTION
Canonical integration for #140 using the existing Pcg64 engine. Adds reproducible uniform, normal, and integer Buffer generation with finite parameter validation, a zero-safe Box-Muller path, checked shape allocation, signed-wide-range arithmetic, and rejection sampling without modulo bias. Incorporates only relevant validation ideas from #257; #263 is prior art, not merged wholesale. Refs #140.