### PR TITLE
feat(buffer): add concatenate and stack

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -14,9 +14,10 @@
 use std::{ptr::NonNull, sync::Arc};
 
 use mohu_dtype::{
+    dispatch_dtype,
     dlpack::{DLDataType, assert_cpu_device},
     dtype::DType,
-    promote::CastMode,
+    promote::{CastMode, common_type},
     scalar::Scalar,
 };
 use mohu_error::{MohuError, MohuResult};
@@ -24,7 +25,7 @@ use mohu_error::{MohuError, MohuResult};
 use crate::{
     alloc::{AllocHandle, SIMD_ALIGN},
     layout::{Layout, Order, SliceArg},
-    strides::contiguous_nbytes,
+    strides::{NdIndexIter, contiguous_nbytes},
 };
 
 // ─── BufferFlags ─────────────────────────────────────────────────────────────
@@ -1961,6 +1962,117 @@ impl Buffer {
         }
         let _ = writeln!(s, "}}");
         s
+    }
+
+    // ─── Combine ──────────────────────────────────────────────────────────────
+
+    /// Concatenates buffers along an existing axis into a new owning buffer.
+    ///
+    /// Inputs may be strided views. Their dtypes are promoted using the
+    /// established dtype promotion rules before values are copied.
+    pub fn concatenate(arrays: &[&Buffer], axis: usize) -> MohuResult<Self> {
+        if arrays.is_empty() {
+            return Err(MohuError::EmptyStackSequence);
+        }
+        let ndim = arrays[0].ndim();
+        if ndim == 0 {
+            return Err(MohuError::ScalarArray);
+        }
+        if axis >= ndim {
+            return Err(MohuError::AxisOutOfRange {
+                axis: axis as i64,
+                ndim,
+                valid: format!("0..{ndim}"),
+            });
+        }
+
+        let ref_shape = arrays[0].shape().to_vec();
+        let mut total_axis = 0usize;
+        for (index, array) in arrays.iter().enumerate() {
+            if array.ndim() != ndim {
+                return Err(MohuError::DimensionMismatch {
+                    expected: ndim,
+                    got: array.ndim(),
+                });
+            }
+            for (dimension, (&got, &expected)) in
+                array.shape().iter().zip(ref_shape.iter()).enumerate()
+            {
+                if dimension != axis && got != expected {
+                    return Err(MohuError::ConcatShapeMismatch {
+                        index,
+                        expected: ref_shape.clone(),
+                        got: array.shape().to_vec(),
+                    });
+                }
+            }
+            total_axis = total_axis
+                .checked_add(array.shape()[axis])
+                .ok_or(MohuError::ShapeOverflow { max: usize::MAX })?;
+        }
+
+        let output_dtype =
+            common_type(&arrays.iter().map(|array| array.dtype()).collect::<Vec<_>>())?;
+        let mut output_shape = ref_shape;
+        output_shape[axis] = total_axis;
+        let sources = arrays
+            .iter()
+            .map(|array| array.cast(output_dtype, CastMode::Safe))
+            .collect::<MohuResult<Vec<_>>>()?;
+        let mut output = Self::alloc(output_dtype, &output_shape, Order::C)?;
+
+        // Coordinate-based copying preserves logical order for every valid
+        // strided input and keeps raw-pointer arithmetic out of this API.
+        macro_rules! concatenate_typed {
+            ($T:ty) => {{
+                let mut axis_offset = 0usize;
+                for source in &sources {
+                    for source_coord in NdIndexIter::new(source.shape()) {
+                        let mut output_coord = source_coord.to_vec();
+                        output_coord[axis] += axis_offset;
+                        output.set::<$T>(&output_coord, source.get::<$T>(&source_coord)?)?;
+                    }
+                    axis_offset += source.shape()[axis];
+                }
+                Ok(output)
+            }};
+        }
+        dispatch_dtype!(output_dtype, concatenate_typed)
+    }
+
+    /// Stacks buffers along a new axis into a new owning buffer.
+    ///
+    /// All inputs must have identical shapes. The new axis may be inserted at
+    /// any position from `0` through the input rank, inclusive.
+    pub fn stack(arrays: &[&Buffer], axis: usize) -> MohuResult<Self> {
+        if arrays.is_empty() {
+            return Err(MohuError::EmptyStackSequence);
+        }
+        let ndim = arrays[0].ndim();
+        if axis > ndim {
+            return Err(MohuError::AxisOutOfRange {
+                axis: axis as i64,
+                ndim,
+                valid: format!("0..={ndim}"),
+            });
+        }
+        let shape = arrays[0].shape();
+        for (index, array) in arrays.iter().enumerate() {
+            if array.shape() != shape {
+                return Err(MohuError::ConcatShapeMismatch {
+                    index,
+                    expected: shape.to_vec(),
+                    got: array.shape().to_vec(),
+                });
+            }
+        }
+
+        let expanded = arrays
+            .iter()
+            .map(|array| array.expand_dims(axis))
+            .collect::<MohuResult<Vec<_>>>()?;
+        let refs = expanded.iter().collect::<Vec<_>>();
+        Self::concatenate(&refs, axis)
     }
 }
 

--- a/crates/mohu-buffer/tests/combine.rs
+++ b/crates/mohu-buffer/tests/combine.rs
@@ -1,0 +1,132 @@
+use mohu_buffer::{Buffer, MohuError};
+use mohu_dtype::dtype::DType;
+
+fn matrix<T: mohu_dtype::scalar::Scalar>(values: &[T], shape: &[usize]) -> Buffer {
+    Buffer::from_slice(values).unwrap().reshape(shape).unwrap()
+}
+
+#[test]
+fn concatenate_handles_axes_and_exact_order() {
+    let a = matrix(&[1_i32, 2, 3, 4], &[2, 2]);
+    let b = matrix(&[5_i32, 6], &[1, 2]);
+    let out = Buffer::concatenate(&[&a, &b], 0).unwrap();
+    assert_eq!(out.shape(), &[3, 2]);
+    assert_eq!(out.to_vec::<i32>().unwrap(), vec![1, 2, 3, 4, 5, 6]);
+
+    let c = matrix(&[7_i32, 8, 9, 10], &[2, 2]);
+    let wide = Buffer::concatenate(&[&a, &c], 1).unwrap();
+    assert_eq!(wide.shape(), &[2, 4]);
+    assert_eq!(wide.to_vec::<i32>().unwrap(), vec![1, 2, 7, 8, 3, 4, 9, 10]);
+}
+
+#[test]
+fn concatenate_promotes_and_accepts_strided_views() {
+    let base = matrix(&[1.0_f32, 2.0, 3.0, 4.0], &[2, 2]);
+    let transposed = base.transpose();
+    let other = matrix(&[5.0_f64, 6.0], &[2, 1]);
+    let out = Buffer::concatenate(&[&transposed, &other], 1).unwrap();
+    assert_eq!(out.dtype(), DType::F64);
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(
+        out.to_vec::<f64>().unwrap(),
+        vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
+    );
+}
+
+#[test]
+fn concatenate_uses_current_typed_errors() {
+    let a = matrix(&[1_i32, 2], &[1, 2]);
+    assert!(matches!(
+        Buffer::concatenate(&[], 0),
+        Err(MohuError::EmptyStackSequence)
+    ));
+    assert!(matches!(
+        Buffer::concatenate(&[&a], 2),
+        Err(MohuError::AxisOutOfRange { .. })
+    ));
+    let b = matrix(&[3_i32, 4, 5], &[1, 3]);
+    assert!(matches!(
+        Buffer::concatenate(&[&a, &b], 0),
+        Err(MohuError::ConcatShapeMismatch { .. })
+    ));
+    let scalar = Buffer::from_slice(&[1_i32]).unwrap().reshape(&[]).unwrap();
+    assert!(matches!(
+        Buffer::concatenate(&[&scalar], 0),
+        Err(MohuError::ScalarArray)
+    ));
+}
+
+#[test]
+fn stack_inserts_axis_and_preserves_order() {
+    let a = matrix(&[1_i32, 2, 3, 4], &[2, 2]);
+    let b = matrix(&[5_i32, 6, 7, 8], &[2, 2]);
+    for (axis, shape, expected) in [
+        (0, vec![2, 2, 2], vec![1, 2, 3, 4, 5, 6, 7, 8]),
+        (1, vec![2, 2, 2], vec![1, 2, 5, 6, 3, 4, 7, 8]),
+        (2, vec![2, 2, 2], vec![1, 5, 2, 6, 3, 7, 4, 8]),
+    ] {
+        let out = Buffer::stack(&[&a, &b], axis).unwrap();
+        assert_eq!(out.shape(), shape.as_slice());
+        assert_eq!(out.to_vec::<i32>().unwrap(), expected);
+    }
+}
+
+#[test]
+fn stack_supports_scalar_and_strided_inputs() {
+    let scalar_a = Buffer::from_slice(&[2_i32]).unwrap().reshape(&[]).unwrap();
+    let scalar_b = Buffer::from_slice(&[3_i32]).unwrap().reshape(&[]).unwrap();
+    let scalars = Buffer::stack(&[&scalar_a, &scalar_b], 0).unwrap();
+    assert_eq!(scalars.shape(), &[2]);
+    assert_eq!(scalars.to_vec::<i32>().unwrap(), vec![2, 3]);
+
+    let base = matrix(&[1_i32, 2, 3, 4], &[2, 2]);
+    let view = base.transpose();
+    let out = Buffer::stack(&[&view, &view], 0).unwrap();
+    assert_eq!(out.shape(), &[2, 2, 2]);
+    assert_eq!(out.to_vec::<i32>().unwrap(), vec![1, 3, 2, 4, 1, 3, 2, 4]);
+}
+
+#[test]
+fn empty_combine_results_are_valid() {
+    let a = matrix::<i32>(&[], &[0, 3]);
+    let b = matrix::<i32>(&[], &[0, 3]);
+    let concat = Buffer::concatenate(&[&a, &b], 0).unwrap();
+    assert_eq!(concat.shape(), &[0, 3]);
+    assert_eq!(concat.len(), 0);
+
+    let stack = Buffer::stack(&[&a, &b], 1).unwrap();
+    assert_eq!(stack.shape(), &[0, 2, 3]);
+    assert_eq!(stack.len(), 0);
+}
+
+#[test]
+fn combined_output_is_new_owning_c_buffer() {
+    let a = matrix(&[1_i32, 2], &[2]);
+    let out = Buffer::concatenate(&[&a], 0).unwrap();
+    assert!(out.is_c_contiguous());
+    assert!(!out.is_shared());
+    assert_eq!(out.to_vec::<i32>().unwrap(), vec![1, 2]);
+}
+
+#[test]
+fn concatenate_preserves_complex_values_and_promotes_float_types() {
+    use num_complex::Complex;
+    let a = matrix(&[Complex::new(1.0_f32, 2.0), Complex::new(3.0, 4.0)], &[2]);
+    let b = matrix(&[Complex::new(5.0_f32, 6.0)], &[1]);
+    let out = Buffer::concatenate(&[&a, &b], 0).unwrap();
+    assert_eq!(out.dtype(), DType::C64);
+    assert_eq!(
+        out.to_vec::<Complex<f32>>().unwrap(),
+        vec![
+            Complex::new(1.0, 2.0),
+            Complex::new(3.0, 4.0),
+            Complex::new(5.0, 6.0),
+        ]
+    );
+
+    let low = Buffer::from_slice(&[1.0_f32, 2.0]).unwrap();
+    let high = Buffer::from_slice(&[3.0_f64, 4.0]).unwrap();
+    let stacked = Buffer::stack(&[&low, &high], 0).unwrap();
+    assert_eq!(stacked.dtype(), DType::F64);
+    assert_eq!(stacked.to_vec::<f64>().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+}


### PR DESCRIPTION
Canonical current-main integration for #144, extracting the useful Buffer combine work from #168 without its unrelated historical CI/dtype changes.

Adds safe axis-aware concatenate and stack operations with current typed errors, common-type promotion, strided input support, owning C-contiguous outputs, zero-size handling, and focused tests.

Refs #144
Prior art: #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added buffer concatenation along existing axes.
  * Added buffer stacking along new axes.
  * Supports dtype promotion and scalar, empty, strided, and transposed inputs.
  * Added validation for incompatible shapes and invalid axes.

* **Tests**
  * Added coverage for element ordering, axis behavior, dtype promotion, error handling, and output buffer layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->