### PR TITLE
feat(ops): add Buffer matmul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,12 @@ dependencies = [
 name = "mohu-ops"
 version = "0.1.0"
 dependencies = [
+ "half",
+ "mohu-buffer",
  "mohu-core",
+ "mohu-dtype",
+ "mohu-error",
+ "num-complex",
  "num-traits",
  "rayon",
  "thiserror",

--- a/crates/mohu-ops/Cargo.toml
+++ b/crates/mohu-ops/Cargo.toml
@@ -24,4 +24,4 @@ thiserror.workspace   = true
 
 
 [package.metadata.cargo-machete]
-ignored = ["mohu-core", "num-traits", "rayon", "thiserror"]
+ignored = ["mohu-core", "num-traits", "rayon", "thiserror", "half"]

--- a/crates/mohu-ops/Cargo.toml
+++ b/crates/mohu-ops/Cargo.toml
@@ -13,6 +13,11 @@ categories.workspace  = true
 
 [dependencies]
 mohu-core.workspace   = true
+mohu-buffer.workspace = true
+mohu-dtype.workspace  = true
+mohu-error.workspace  = true
+half.workspace        = true
+num-complex.workspace = true
 num-traits.workspace  = true
 rayon.workspace       = true
 thiserror.workspace   = true

--- a/crates/mohu-ops/src/lib.rs
+++ b/crates/mohu-ops/src/lib.rs
@@ -2,5 +2,6 @@ pub mod arith;
 pub mod broadcast;
 pub mod cmp;
 pub mod logical;
+pub mod matmul;
 pub mod reduce;
 pub mod unary;

--- a/crates/mohu-ops/src/matmul.rs
+++ b/crates/mohu-ops/src/matmul.rs
@@ -1,0 +1,103 @@
+//! Buffer-facing matrix multiplication semantics.
+
+use mohu_buffer::{Buffer, Order};
+use mohu_dtype::{dispatch_numeric, dtype::DType, promote::CastMode, scalar::Scalar};
+use mohu_error::{MohuError, MohuResult};
+
+/// Multiplies one- or two-dimensional buffers without batch broadcasting.
+///
+/// Integer inputs produce `F64` output. Other numeric inputs use the current
+/// promoted dtype. Operands may be strided; they are materialized as needed.
+/// The private reference kernel is deliberately kept behind this semantic API
+/// so a future `mohu-linalg` backend can replace it without changing callers.
+pub fn matmul(lhs: &Buffer, rhs: &Buffer) -> MohuResult<Buffer> {
+    let lhs_rank = lhs.ndim();
+    let rhs_rank = rhs.ndim();
+    let (m, k, n, output_shape) = match (lhs_rank, rhs_rank) {
+        (2, 2) => {
+            let (m, k) = (lhs.shape()[0], lhs.shape()[1]);
+            let (rhs_k, n) = (rhs.shape()[0], rhs.shape()[1]);
+            validate_k(k, rhs_k)?;
+            (m, k, n, vec![m, n])
+        },
+        (1, 2) => {
+            let k = lhs.shape()[0];
+            let (rhs_k, n) = (rhs.shape()[0], rhs.shape()[1]);
+            validate_k(k, rhs_k)?;
+            (1, k, n, vec![n])
+        },
+        (2, 1) => {
+            let (m, k) = (lhs.shape()[0], lhs.shape()[1]);
+            let rhs_k = rhs.shape()[0];
+            validate_k(k, rhs_k)?;
+            (m, k, 1, vec![m])
+        },
+        (1, 1) => {
+            let k = lhs.shape()[0];
+            let rhs_k = rhs.shape()[0];
+            validate_k(k, rhs_k)?;
+            (1, k, 1, vec![])
+        },
+        (lhs_rank, rhs_rank) => {
+            return Err(MohuError::DimensionMismatch {
+                expected: 1,
+                got: lhs_rank.max(rhs_rank),
+            });
+        },
+    };
+
+    let promoted = mohu_dtype::promote::promote(lhs.dtype(), rhs.dtype());
+    let output_dtype = if promoted.is_integer() {
+        DType::F64
+    } else {
+        promoted
+    };
+    let lhs = lhs.cast(output_dtype, CastMode::Safe)?;
+    let rhs = rhs.cast(output_dtype, CastMode::Safe)?;
+    let mut output = Buffer::alloc(output_dtype, &output_shape, Order::C)?;
+
+    macro_rules! multiply {
+        ($T:ty) => {{
+            matmul_typed::<$T>(&lhs, &rhs, &mut output, m, k, n)?;
+            Ok::<Buffer, MohuError>(output)
+        }};
+    }
+    dispatch_numeric!(output_dtype, multiply)?
+}
+
+fn validate_k(lhs_k: usize, rhs_k: usize) -> MohuResult<()> {
+    if lhs_k != rhs_k {
+        return Err(MohuError::ShapeMismatch {
+            expected: vec![lhs_k],
+            got: vec![rhs_k],
+        });
+    }
+    Ok(())
+}
+
+/// Reference O(M*K*N) kernel. Future optimized backends stay behind `matmul`.
+fn matmul_typed<T>(
+    lhs: &Buffer,
+    rhs: &Buffer,
+    output: &mut Buffer,
+    m: usize,
+    k: usize,
+    n: usize,
+) -> MohuResult<()>
+where
+    T: Scalar + std::ops::Add<Output = T> + std::ops::Mul<Output = T>,
+{
+    let lhs_values = lhs.as_slice::<T>()?;
+    let rhs_values = rhs.as_slice::<T>()?;
+    let output_values = output.as_mut_slice::<T>()?;
+    for row in 0..m {
+        for column in 0..n {
+            let mut sum = T::ZERO;
+            for inner in 0..k {
+                sum = sum + lhs_values[row * k + inner] * rhs_values[inner * n + column];
+            }
+            output_values[row * n + column] = sum;
+        }
+    }
+    Ok(())
+}

--- a/crates/mohu-ops/tests/matmul_tests.rs
+++ b/crates/mohu-ops/tests/matmul_tests.rs
@@ -1,0 +1,144 @@
+use mohu_buffer::Buffer;
+use mohu_dtype::dtype::DType;
+use mohu_error::MohuError;
+use mohu_ops::matmul::matmul;
+
+fn matrix<T: mohu_dtype::scalar::Scalar>(values: &[T], shape: &[usize]) -> Buffer {
+    Buffer::from_slice(values).unwrap().reshape(shape).unwrap()
+}
+
+#[test]
+fn matmul_supports_all_rank_combinations() {
+    let vector = Buffer::from_slice(&[1.0_f32, 2.0, 3.0]).unwrap();
+    let matrix_rhs = matrix(&[1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0], &[3, 2]);
+    assert_eq!(
+        matmul(&vector, &matrix_rhs)
+            .unwrap()
+            .to_vec::<f32>()
+            .unwrap(),
+        vec![22.0, 28.0]
+    );
+
+    let matrix_lhs = matrix(&[1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
+    let rhs_vector = Buffer::from_slice(&[1.0_f32, 2.0, 3.0]).unwrap();
+    assert_eq!(
+        matmul(&matrix_lhs, &rhs_vector)
+            .unwrap()
+            .to_vec::<f32>()
+            .unwrap(),
+        vec![14.0, 32.0]
+    );
+
+    let dot = matmul(&vector, &rhs_vector).unwrap();
+    assert_eq!(dot.shape(), &[] as &[usize]);
+    assert_eq!(dot.to_vec::<f32>().unwrap(), vec![14.0]);
+}
+
+#[test]
+fn matmul_2d_and_rectangular() {
+    let lhs = matrix(&[1.0_f32, 2.0, 3.0, 4.0], &[2, 2]);
+    let rhs = matrix(&[5.0_f32, 6.0, 7.0, 8.0], &[2, 2]);
+    assert_eq!(
+        matmul(&lhs, &rhs).unwrap().to_vec::<f32>().unwrap(),
+        vec![19.0, 22.0, 43.0, 50.0]
+    );
+
+    let wide = matrix(&[1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
+    let tall = matrix(&[1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0], &[3, 2]);
+    let out = matmul(&wide, &tall).unwrap();
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_eq!(out.to_vec::<f32>().unwrap(), vec![22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn matmul_validates_rank_and_shared_dimension() {
+    let scalar = Buffer::from_slice(&[2.0_f32])
+        .unwrap()
+        .reshape(&[])
+        .unwrap();
+    let vector = Buffer::from_slice(&[1.0_f32, 2.0]).unwrap();
+    assert!(matches!(
+        matmul(&scalar, &vector),
+        Err(MohuError::DimensionMismatch { .. })
+    ));
+
+    let lhs = matrix(&[1.0_f32, 2.0, 3.0, 4.0], &[2, 2]);
+    let rhs = matrix(&[1.0_f32, 2.0, 3.0], &[3, 1]);
+    assert!(matches!(
+        matmul(&lhs, &rhs),
+        Err(MohuError::ShapeMismatch { .. })
+    ));
+}
+
+#[test]
+fn matmul_promotes_integer_inputs_to_f64() {
+    let lhs = matrix(&[1_i32, 2, 3, 4], &[2, 2]);
+    let rhs = matrix(&[5_i32, 6, 7, 8], &[2, 2]);
+    let out = matmul(&lhs, &rhs).unwrap();
+    assert_eq!(out.dtype(), DType::F64);
+    assert_eq!(out.to_vec::<f64>().unwrap(), vec![19.0, 22.0, 43.0, 50.0]);
+}
+
+#[test]
+fn matmul_mixes_integer_and_float_inputs() {
+    let lhs = matrix(&[1_i32, 2], &[1, 2]);
+    let rhs = matrix(&[3.0_f32, 4.0], &[2, 1]);
+    let out = matmul(&lhs, &rhs).unwrap();
+    assert_eq!(out.dtype(), DType::F64);
+    assert_eq!(out.to_vec::<f64>().unwrap(), vec![11.0]);
+}
+
+#[test]
+fn matmul_preserves_complex_arithmetic() {
+    use num_complex::Complex;
+    let lhs = matrix(
+        &[Complex::new(1.0_f32, 2.0), Complex::new(3.0, 4.0)],
+        &[1, 2],
+    );
+    let rhs = matrix(
+        &[Complex::new(5.0_f32, 6.0), Complex::new(7.0, 8.0)],
+        &[2, 1],
+    );
+    let out = matmul(&lhs, &rhs).unwrap();
+    assert_eq!(out.dtype(), DType::C64);
+    assert_eq!(
+        out.to_vec::<Complex<f32>>().unwrap(),
+        vec![Complex::new(-18.0, 68.0)]
+    );
+}
+
+#[test]
+fn matmul_accepts_non_contiguous_operands_and_zero_k() {
+    let lhs_base = matrix(&[1.0_f32, 2.0, 3.0, 4.0], &[2, 2]);
+    let lhs = lhs_base.transpose();
+    let rhs = matrix(&[5.0_f32, 6.0, 7.0, 8.0], &[2, 2]);
+    assert_eq!(
+        matmul(&lhs, &rhs).unwrap().to_vec::<f32>().unwrap(),
+        vec![26.0, 30.0, 38.0, 44.0]
+    );
+
+    let empty_lhs = matrix::<f32>(&[], &[2, 0]);
+    let empty_rhs = matrix::<f32>(&[], &[0, 3]);
+    let out = matmul(&empty_lhs, &empty_rhs).unwrap();
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(out.to_vec::<f32>().unwrap(), vec![0.0; 6]);
+}
+
+#[test]
+fn matmul_output_is_contiguous_and_owning() {
+    let lhs = matrix(&[1.0_f64, 2.0], &[1, 2]);
+    let rhs = matrix(&[3.0_f64, 4.0], &[2, 1]);
+    let out = matmul(&lhs, &rhs).unwrap();
+    assert!(out.is_c_contiguous());
+    assert!(!out.is_shared());
+}
+
+#[test]
+fn matmul_rejects_bool_inputs() {
+    let lhs = Buffer::from_slice(&[true, false]).unwrap();
+    let rhs = Buffer::from_slice(&[true, true]).unwrap();
+    assert!(matches!(
+        matmul(&lhs, &rhs),
+        Err(MohuError::UnsupportedDType { .. })
+    ));
+}


### PR DESCRIPTION
Canonical current-main implementation for #152, reconciling the useful matmul work from #299 without its historical uncertainty or dependency churn.

`mohu-ops` owns Buffer-facing rank/shape/dtype semantics. Supports 1D/2D combinations, integer-to-F64 output, complex arithmetic, strided inputs, zero-K results, and a safe private reference kernel. `mohu-linalg` remains standalone and is a future backend seam.

Refs #152
Prior art: #299