### PR TITLE
feat(array): add typed NdArray foundation

### DIFF
--- a/CRATE_MAP.md
+++ b/CRATE_MAP.md
@@ -65,11 +65,11 @@ Structured map of all workspace crates, their dependencies, modules, and public 
 ### `mohu-array`
 **Description**: NdArray — the core N-dimensional array type.
 **Dependencies**: `mohu-error`, `mohu-dtype`, `mohu-buffer`, `num-traits`, `rayon`
-**Status**: Module stubs declared; source files are empty (not yet implemented).
+**Status**: Partial — NdArray construction and metadata are implemented; indexing, views, and arithmetic remain incomplete.
 
 | Module | Status |
 |--------|--------|
-| `array` | `[stub]` |
+| `array` | NdArray construction and metadata |
 | `iter` | `[stub]` |
 | `shape` | `[stub]` |
 | `slice` | `[stub]` |
@@ -321,7 +321,7 @@ Structured map of all workspace crates, their dependencies, modules, and public 
 mohu-error (standalone)
   └─► mohu-dtype
         └─► mohu-buffer
-              └─► mohu-array [stub]
+              └─► mohu-array [partial]
                     └─► mohu-core (facade: re-exports error + dtype + buffer + array)
 
 mohu-simd ──► mohu-error, mohu-dtype
@@ -348,7 +348,7 @@ mohu-testing ──► mohu-error, mohu-dtype, mohu-buffer, approx, proptest
 | `mohu-error` | **Fully implemented** — all modules have source code |
 | `mohu-dtype` | **Fully implemented** — all modules have source code |
 | `mohu-buffer` | **Fully implemented** — all modules have source code |
-| `mohu-array` | Stubs only — module files empty |
+| `mohu-array` | Partial — NdArray construction and metadata implemented |
 | `mohu-core` | **Implemented** — re-export facade (5 lines) |
 | `mohu-simd` | Stubs only |
 | `mohu-ufunc` | Stubs only |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,9 +649,11 @@ dependencies = [
 name = "mohu-array"
 version = "0.1.0"
 dependencies = [
+ "half",
  "mohu-buffer",
  "mohu-dtype",
  "mohu-error",
+ "num-complex",
  "num-traits",
  "rayon",
 ]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ if a crate says *stub*, its implementation modules contain no public implementat
 | `mohu-dtype` | 15 dtypes, scalar traits, promotion, `finfo`/`iinfo`, DLPack codes | ✅ implemented |
 | `mohu-buffer` | Aligned/mmap allocation, layout, strides, views, DLPack, pool | ✅ implemented |
 | `mohu-random` | PCG64 / Philox PRNG + distributions | 🟡 partial |
-| `mohu-array` | `NdArray<T>` — the user-facing array type | ⬜ stub |
+| `mohu-array` | `NdArray<T>` — typed construction and metadata; indexing and views pending | ◐ partial |
 | `mohu-core` | Re-export facade over the foundation crates | ⬜ stub |
 | `mohu-simd` | AVX2 / AVX-512 / NEON kernels | ⬜ stub |
 | `mohu-ufunc` | Universal-function protocol: broadcast, reduce, outer | ⬜ stub |

--- a/crates/mohu-array/Cargo.toml
+++ b/crates/mohu-array/Cargo.toml
@@ -21,3 +21,7 @@ rayon.workspace       = true
 
 [package.metadata.cargo-machete]
 ignored = ["mohu-buffer", "mohu-dtype", "mohu-error", "num-traits", "rayon"]
+
+[dev-dependencies]
+half.workspace = true
+num-complex.workspace = true

--- a/crates/mohu-array/README.md
+++ b/crates/mohu-array/README.md
@@ -10,7 +10,7 @@
 NdArray<T>  =  mohu-buffer::Buffer  +  type parameter T : Scalar (from mohu-dtype)
 ```
 
-`mohu-buffer` owns the raw bytes, shape, and strides. `mohu-array` adds the generic type parameter `T` (bounded by `num-traits` scalar traits and `mohu-dtype`'s type system) so that element-level operations are type-safe without runtime casting. Parallel operations are powered by `rayon`.
+`mohu-buffer` owns the raw bytes, shape, and strides. `mohu-array` adds the generic type parameter `T: MohuElement` from `mohu-dtype` so construction and introspection remain type-safe without duplicating storage metadata.
 
 Internal modules:
 
@@ -26,8 +26,7 @@ Internal modules:
 
 ## Planned API Surface
 
-> **Status:** implementation is in progress — all source files are currently stubs.
-> The API below reflects the planned design; signatures may change before stabilisation.
+> **Status:** NdArray construction and introspection are implemented. Indexing, views, arithmetic, and shaped construction remain planned; signatures may change before stabilisation.
 > See the [issue tracker](https://github.com/mohu-org/mohu/issues?q=label%3A%22crate%3A+mohu-array%22) for progress.
 
 ### Construction
@@ -40,7 +39,7 @@ let a = NdArray::<f64>::zeros(&[3, 4]);
 let b = NdArray::<f32>::ones(&[2, 2, 2]);
 
 // From an existing flat slice (row-major by default)
-let c = NdArray::<i32>::from_slice(&[1, 2, 3, 4, 5, 6], &[2, 3]);
+let c = NdArray::<i32>::from_slice(&[1, 2, 3, 4, 5, 6]); // 1-D
 ```
 
 ### Indexing
@@ -82,7 +81,7 @@ let t = a.transpose();
 
 ## Status
 
-`mohu-array` is **under active development** and is not yet published to [crates.io](https://crates.io). All `.rs` files are currently module stubs. Implementation is being tracked in the [mohu issue tracker](https://github.com/mohu-org/mohu/issues?q=label%3A%22crate%3A+mohu-array%22).
+`mohu-array` is **under active development** and is not yet published to [crates.io](https://crates.io). Construction and metadata are implemented; indexing, views, and arithmetic remain incomplete. See the [issue tracker](https://github.com/mohu-org/mohu/issues?q=label%3A%22crate%3A+mohu-array%22).
 
 Do not depend on this crate in production — public API stability is not guaranteed before the first versioned release.
 

--- a/crates/mohu-array/src/array.rs
+++ b/crates/mohu-array/src/array.rs
@@ -1,1 +1,86 @@
+use std::marker::PhantomData;
 
+use mohu_buffer::buffer::Buffer;
+use mohu_dtype::dtype::DType;
+use mohu_dtype::scalar::Scalar;
+use mohu_error::MohuResult;
+
+/// Element types supported by [`NdArray`].
+pub trait MohuElement: Scalar {}
+
+impl<T: Scalar> MohuElement for T {}
+
+/// Typed N-dimensional array backed by [`Buffer`].
+pub struct NdArray<T: MohuElement> {
+    buffer: Buffer,
+    _marker: PhantomData<T>,
+}
+
+impl<T: MohuElement> NdArray<T> {
+    /// Creates an array filled with zero values.
+    pub fn zeros(shape: &[usize]) -> MohuResult<Self> {
+        Ok(Self {
+            buffer: Buffer::zeros(T::DTYPE, shape)?,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Creates an array filled with one values.
+    pub fn ones(shape: &[usize]) -> MohuResult<Self> {
+        Ok(Self {
+            buffer: Buffer::ones(T::DTYPE, shape)?,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Creates a one-dimensional array by copying `data`.
+    pub fn from_slice(data: &[T]) -> MohuResult<Self> {
+        Ok(Self {
+            buffer: Buffer::from_slice(data)?,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Returns the array shape.
+    pub fn shape(&self) -> &[usize] {
+        self.buffer.shape()
+    }
+
+    /// Returns the number of dimensions.
+    pub fn ndim(&self) -> usize {
+        self.buffer.ndim()
+    }
+
+    /// Returns the number of elements.
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Returns whether the array has no elements.
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    /// Returns the runtime dtype of the backing buffer.
+    pub fn dtype(&self) -> DType {
+        self.buffer.dtype()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NdArray;
+
+    #[test]
+    fn constructors_store_expected_values() {
+        let zeros = NdArray::<f64>::zeros(&[2]).unwrap();
+        assert_eq!(zeros.buffer.to_vec::<f64>().unwrap(), vec![0.0, 0.0]);
+
+        let ones = NdArray::<f32>::ones(&[2]).unwrap();
+        assert_eq!(ones.buffer.to_vec::<f32>().unwrap(), vec![1.0, 1.0]);
+
+        let data = [3_i32, -2, 7];
+        let copied = NdArray::<i32>::from_slice(&data).unwrap();
+        assert_eq!(copied.buffer.to_vec::<i32>().unwrap(), data);
+    }
+}

--- a/crates/mohu-array/src/lib.rs
+++ b/crates/mohu-array/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod array;
+pub use array::{MohuElement, NdArray};
 pub mod iter;
 pub mod shape;
 pub mod slice;

--- a/crates/mohu-array/tests/array_tests.rs
+++ b/crates/mohu-array/tests/array_tests.rs
@@ -1,0 +1,57 @@
+use mohu_array::NdArray;
+use mohu_dtype::DType;
+
+#[test]
+fn zeros_metadata() {
+    let a = NdArray::<f64>::zeros(&[3, 4]).unwrap();
+    assert_eq!(a.shape(), &[3, 4]);
+    assert_eq!(a.ndim(), 2);
+    assert_eq!(a.len(), 12);
+    assert!(!a.is_empty());
+    assert_eq!(a.dtype(), DType::F64);
+}
+
+#[test]
+fn ones_metadata() {
+    let a = NdArray::<f32>::ones(&[2, 2, 2]).unwrap();
+    assert_eq!(a.shape(), &[2, 2, 2]);
+    assert_eq!(a.len(), 8);
+    assert_eq!(a.dtype(), DType::F32);
+}
+
+#[test]
+fn from_slice_is_one_dimensional() {
+    let a = NdArray::<i32>::from_slice(&[1, 2, 3]).unwrap();
+    assert_eq!(a.shape(), &[3]);
+    assert_eq!(a.ndim(), 1);
+    assert_eq!(a.len(), 3);
+    assert_eq!(a.dtype(), DType::I32);
+}
+
+#[test]
+fn scalar_and_zero_sized_shapes() {
+    let scalar = NdArray::<f64>::zeros(&[]).unwrap();
+    let scalar_shape: &[usize] = &[];
+    assert_eq!(scalar.shape(), scalar_shape);
+    assert_eq!(scalar.ndim(), 0);
+    assert_eq!(scalar.len(), 1);
+    assert!(!scalar.is_empty());
+
+    let empty = NdArray::<f64>::ones(&[2, 0, 4]).unwrap();
+    assert_eq!(empty.len(), 0);
+    assert!(empty.is_empty());
+}
+
+#[test]
+fn all_supported_dtypes_report_runtime_type() {
+    macro_rules! check { ($($ty:ty => $dtype:expr),+ $(,)?) => { $(assert_eq!(NdArray::<$ty>::zeros(&[1]).unwrap().dtype(), $dtype);)+ }; }
+    check!(
+        bool => DType::Bool,
+        i8 => DType::I8, i16 => DType::I16, i32 => DType::I32, i64 => DType::I64,
+        u8 => DType::U8, u16 => DType::U16, u32 => DType::U32, u64 => DType::U64,
+        half::f16 => DType::F16, half::bf16 => DType::BF16,
+        f32 => DType::F32, f64 => DType::F64,
+        num_complex::Complex<f32> => DType::C64,
+        num_complex::Complex<f64> => DType::C128,
+    );
+}


### PR DESCRIPTION
Implements #151 from current main.

Extracts the construction and introspection portion of #236 without its unrelated historical changes.

Included:
- typed `NdArray<T>` over `Buffer`
- `zeros`, `ones`, one-dimensional `from_slice`
- shape/ndim/len/is_empty/dtype accessors
- exhaustive dtype and edge-case tests
- truthful array README and status-map updates

Intentionally deferred: Clone, Debug, Deref, indexing, views, arithmetic, and shaped construction.

Relates to #236; closes #151 when merged.