### PR TITLE
feat(fft): add Buffer complex transforms

### DIFF
--- a/crates/mohu-fft/src/lib.rs
+++ b/crates/mohu-fft/src/lib.rs
@@ -1,10 +1,11 @@
 /// Fast Fourier Transforms for mohu.
 ///
-/// Wraps `rustfft` for the core Cooley-Tukey algorithm and adds:
-/// - N-dimensional FFT / IFFT over arbitrary axes
-/// - Real-input FFT (`rfft`) producing Hermitian-symmetric output
-/// - Frequency axis helpers (`fftfreq`, `rfftfreq`, `fftshift`)
-/// - Parallel batch transforms via Rayon
+/// Wraps `rustfft` for complex transforms over Buffer values.
+///
+/// Implemented here: C64/C128 FFT and inverse FFT along one arbitrary axis,
+/// including normalization, zero-padding, and truncation. Real-input transforms,
+/// frequency helpers, multidimensional transforms, and parallel batch execution
+/// remain tracked separately.
 ///
 /// # Equivalents
 ///
@@ -36,3 +37,4 @@ pub mod transform;
 
 pub use mohu_error::{MohuError, MohuResult};
 pub use norm::Norm;
+pub use transform::{fft, ifft};

--- a/crates/mohu-fft/src/transform.rs
+++ b/crates/mohu-fft/src/transform.rs
@@ -1,1 +1,118 @@
-// transform — implementation pending
+use crate::norm::Norm;
+use mohu_buffer::{Buffer, NdIndexIter, Order};
+use mohu_dtype::DType;
+use mohu_error::{MohuError, MohuResult};
+use num_complex::Complex;
+use num_traits::{FromPrimitive, Zero};
+use rustfft::FftPlanner;
+
+fn validate(input: &Buffer, n: Option<usize>, axis: usize) -> MohuResult<usize> {
+    if axis >= input.ndim() {
+        return Err(MohuError::AxisOutOfRange {
+            axis: axis as i64,
+            ndim: input.ndim(),
+            valid: if input.ndim() == 0 {
+                "none".into()
+            } else {
+                format!("0..{}", input.ndim() - 1)
+            },
+        });
+    }
+    let len = n.unwrap_or(input.shape()[axis]);
+    if len == 0 {
+        return Err(MohuError::ZeroSizedDimension { axis });
+    }
+    if !matches!(input.dtype(), DType::C64 | DType::C128) {
+        return Err(MohuError::UnsupportedDType {
+            op: "fft",
+            dtype: input.dtype().to_string(),
+        });
+    }
+    Ok(len)
+}
+fn factor(norm: Norm, inverse: bool, n: usize) -> f64 {
+    match (norm, inverse) {
+        (Norm::Backward, false) | (Norm::Forward, true) => 1.0,
+        (Norm::Backward, true) | (Norm::Forward, false) => 1.0 / n as f64,
+        (Norm::Ortho, _) => 1.0 / (n as f64).sqrt(),
+    }
+}
+macro_rules! transform_lines {
+    ($name:ident, $real:ty) => {
+        fn $name(
+            input: &Buffer,
+            output: &mut Buffer,
+            n: usize,
+            axis: usize,
+            norm: Norm,
+            inverse: bool,
+        ) -> MohuResult<()> {
+            let outer: Vec<usize> = input
+                .shape()
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &size)| (i != axis).then_some(size))
+                .collect();
+            let scale =
+                <$real as FromPrimitive>::from_f64(factor(norm, inverse, n)).ok_or_else(|| {
+                    MohuError::UnsupportedDType {
+                        op: "fft normalization",
+                        dtype: input.dtype().to_string(),
+                    }
+                })?;
+            let mut planner = FftPlanner::<$real>::new();
+            let plan = if inverse {
+                planner.plan_fft_inverse(n)
+            } else {
+                planner.plan_fft_forward(n)
+            };
+            for coords in NdIndexIter::new(&outer) {
+                let mut line = vec![Complex::<$real>::new(<$real>::zero(), <$real>::zero()); n];
+                for (k, value) in line.iter_mut().enumerate().take(input.shape()[axis].min(n)) {
+                    let mut index = coords.clone();
+                    index.insert(axis, k);
+                    *value = input.get(&index)?;
+                }
+                plan.process(&mut line);
+                for value in &mut line {
+                    *value *= scale;
+                }
+                for (k, value) in line.into_iter().enumerate() {
+                    let mut index = coords.clone();
+                    index.insert(axis, k);
+                    output.set(&index, value)?;
+                }
+            }
+            Ok(())
+        }
+    };
+}
+transform_lines!(transform_c64, f32);
+transform_lines!(transform_c128, f64);
+
+fn transform(
+    input: &Buffer,
+    n: Option<usize>,
+    axis: usize,
+    norm: Norm,
+    inverse: bool,
+) -> MohuResult<Buffer> {
+    let n = validate(input, n, axis)?;
+    let mut shape = input.shape().to_vec();
+    shape[axis] = n;
+    let mut out = Buffer::alloc(input.dtype(), &shape, Order::C)?;
+    match input.dtype() {
+        DType::C64 => transform_c64(input, &mut out, n, axis, norm, inverse)?,
+        DType::C128 => transform_c128(input, &mut out, n, axis, norm, inverse)?,
+        _ => unreachable!(),
+    };
+    Ok(out)
+}
+/// Computes a complex FFT independently along one Buffer axis.
+pub fn fft(input: &Buffer, n: Option<usize>, axis: usize, norm: Norm) -> MohuResult<Buffer> {
+    transform(input, n, axis, norm, false)
+}
+/// Computes the inverse complex FFT independently along one Buffer axis.
+pub fn ifft(input: &Buffer, n: Option<usize>, axis: usize, norm: Norm) -> MohuResult<Buffer> {
+    transform(input, n, axis, norm, true)
+}

--- a/crates/mohu-fft/tests/transform.rs
+++ b/crates/mohu-fft/tests/transform.rs
@@ -1,0 +1,97 @@
+use mohu_buffer::Buffer;
+use mohu_dtype::DType;
+use mohu_error::MohuError;
+use mohu_fft::{Norm, fft, ifft};
+use num_complex::Complex;
+fn c64(v: &[Complex<f32>], s: &[usize]) -> Buffer {
+    Buffer::from_slice(v).unwrap().reshape(s).unwrap()
+}
+fn c128(v: &[Complex<f64>], s: &[usize]) -> Buffer {
+    Buffer::from_slice(v).unwrap().reshape(s).unwrap()
+}
+fn close(a: Complex<f64>, b: Complex<f64>) {
+    assert!((a.re - b.re).abs() < 1e-9);
+    assert!((a.im - b.im).abs() < 1e-9);
+}
+#[test]
+fn c64_c128_roundtrip_norms() {
+    let x = c64(&[Complex::new(1., 2.), Complex::new(3., -1.)], [2].as_ref());
+    for n in [Norm::Backward, Norm::Ortho, Norm::Forward] {
+        let y = ifft(&fft(&x, None, 0, n).unwrap(), None, 0, n).unwrap();
+        for (a, b) in y
+            .to_vec::<Complex<f32>>()
+            .unwrap()
+            .iter()
+            .zip([Complex::new(1., 2.), Complex::new(3., -1.)])
+        {
+            assert!((a.re - b.re).abs() < 1e-5);
+            assert!((a.im - b.im).abs() < 1e-5);
+        }
+    }
+    let x = c128(&[Complex::new(1., 2.), Complex::new(3., -1.)], [2].as_ref());
+    let y = fft(&x, None, 0, Norm::Backward).unwrap();
+    assert_eq!(y.dtype(), DType::C128);
+    close(y.to_vec::<Complex<f64>>().unwrap()[0], Complex::new(4., 1.));
+}
+#[test]
+fn padding_truncation_and_axes() {
+    let x = c128(
+        &[
+            Complex::new(1., 0.),
+            Complex::new(2., 0.),
+            Complex::new(3., 0.),
+        ],
+        [3].as_ref(),
+    );
+    assert_eq!(fft(&x, Some(5), 0, Norm::Backward).unwrap().shape(), [5]);
+    assert_eq!(fft(&x, Some(2), 0, Norm::Backward).unwrap().shape(), [2]);
+    let m = c128(
+        &[
+            Complex::new(1., 0.),
+            Complex::new(2., 0.),
+            Complex::new(3., 0.),
+            Complex::new(4., 0.),
+        ],
+        [2, 2].as_ref(),
+    );
+    assert_eq!(fft(&m, None, 0, Norm::Backward).unwrap().shape(), [2, 2]);
+}
+#[test]
+fn strided_and_empty_batch() {
+    let x = c128(
+        &[
+            Complex::new(1., 0.),
+            Complex::new(2., 0.),
+            Complex::new(3., 0.),
+            Complex::new(4., 0.),
+        ],
+        [2, 2].as_ref(),
+    )
+    .transpose();
+    assert_eq!(fft(&x, None, 1, Norm::Backward).unwrap().shape(), [2, 2]);
+    let e = c128(&[], [0, 4].as_ref());
+    assert_eq!(fft(&e, None, 1, Norm::Backward).unwrap().shape(), [0, 4]);
+    assert_eq!(fft(&e, Some(4), 0, Norm::Backward).unwrap().shape(), [4, 4]);
+}
+#[test]
+fn invalid_inputs_error() {
+    let x = c128(&[Complex::new(1., 0.)], [1].as_ref());
+    assert!(matches!(
+        fft(&x, None, 1, Norm::Backward),
+        Err(MohuError::AxisOutOfRange { .. })
+    ));
+    assert!(matches!(
+        fft(&x, Some(0), 0, Norm::Backward),
+        Err(MohuError::ZeroSizedDimension { axis: 0 })
+    ));
+    let r = Buffer::zeros(DType::F64, [1].as_ref()).unwrap();
+    assert!(matches!(
+        fft(&r, None, 0, Norm::Backward),
+        Err(MohuError::UnsupportedDType { .. })
+    ));
+    let s = c128(&[Complex::new(1., 0.)], &[]);
+    assert!(matches!(
+        fft(&s, None, 0, Norm::Backward),
+        Err(MohuError::AxisOutOfRange { .. })
+    ));
+}


### PR DESCRIPTION
Implements the Phase-1 portion of #225 from current main.

Included:
- Buffer-facing `fft`/`ifft` APIs with `(input, n, axis, norm)`
- C64 and C128 support
- arbitrary-axis N-D line transforms
- normalization, zero-padding, truncation
- safe non-contiguous input handling
- typed errors for invalid axes, zero lengths, and unsupported dtypes
- focused numerical/layout/error tests

Deferred from umbrella #225: rfft/irfft, fft2/fftn, frequency helpers, fftshift/ifftshift Buffer semantics, and parallel batch optimization.

Refs #225. Extracts only the useful transform work from historical #233; unrelated dtype/error changes and slice-based public API are excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forward and inverse complex FFT transforms along a selected axis.
  * Supports C64 and C128 data, normalization modes, zero-padding, and truncation.
  * FFT functions are now publicly available through the package interface.

* **Bug Fixes**
  * Added validation and clear errors for invalid axes, zero-sized dimensions, and unsupported data types.

* **Tests**
  * Added coverage for round trips, axis selection, strided inputs, empty batches, padding, truncation, and normalization modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->