### PR TITLE
fix(buffer): reject overflowing reshape shapes

### DIFF
--- a/crates/mohu-buffer/src/layout.rs
+++ b/crates/mohu-buffer/src/layout.rs
@@ -438,7 +438,7 @@ impl Layout {
             return Err(MohuError::NonContiguous);
         }
         let src_len = self.size();
-        let dst_len: usize = new_shape.iter().product();
+        let dst_len = crate::strides::shape_size(new_shape)?;
         if src_len != dst_len {
             return Err(MohuError::ReshapeIncompatible {
                 src_len,

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -79,6 +79,13 @@ fn reshape_1d_to_3d() {
 }
 
 #[test]
+fn reshape_rejects_overflowing_destination_shape() {
+    let buf = Buffer::from_slice(&[1_u8]).unwrap();
+    let result = buf.reshape(&[usize::MAX, 2]);
+    assert!(matches!(result, Err(MohuError::ShapeOverflow { .. })));
+}
+
+#[test]
 fn transpose_2d_shape_and_values() {
     let data: Vec<f64> = (0..6).map(|x| x as f64).collect();
     let buf = Buffer::from_slice(&data).unwrap().reshape(&[2, 3]).unwrap();


### PR DESCRIPTION
Use the canonical checked shape-size helper in Layout::reshape so overflowing destination shapes return ShapeOverflow instead of profile-dependent overflow behavior. Adds a focused regression test in debug and release profiles.