### PR TITLE
feat(array): add shaped slice construction

### DIFF
--- a/crates/mohu-array/README.md
+++ b/crates/mohu-array/README.md
@@ -26,7 +26,7 @@ Internal modules:
 
 ## Planned API Surface
 
-> **Status:** NdArray construction and introspection are implemented. Indexing, views, arithmetic, and shaped construction remain planned; signatures may change before stabilisation.
+> **Status:** NdArray construction and introspection are implemented. Indexing, views, and arithmetic remain planned; signatures may change before stabilisation.
 > See the [issue tracker](https://github.com/mohu-org/mohu/issues?q=label%3A%22crate%3A+mohu-array%22) for progress.
 
 ### Construction
@@ -40,6 +40,9 @@ let b = NdArray::<f32>::ones(&[2, 2, 2]);
 
 // From an existing flat slice (row-major by default)
 let c = NdArray::<i32>::from_slice(&[1, 2, 3, 4, 5, 6]); // 1-D
+
+// From flat data with an explicit row-major shape
+let d = NdArray::<i32>::from_shape_slice(&[2, 3], &[1, 2, 3, 4, 5, 6]);
 ```
 
 ### Indexing

--- a/crates/mohu-array/src/array.rs
+++ b/crates/mohu-array/src/array.rs
@@ -41,6 +41,14 @@ impl<T: MohuElement> NdArray<T> {
         })
     }
 
+    /// Creates an array by copying flat row-major data into `shape`.
+    pub fn from_shape_slice(shape: &[usize], data: &[T]) -> MohuResult<Self> {
+        Ok(Self {
+            buffer: Buffer::from_slice(data)?.reshape(shape)?,
+            _marker: PhantomData,
+        })
+    }
+
     /// Returns the array shape.
     pub fn shape(&self) -> &[usize] {
         self.buffer.shape()
@@ -82,5 +90,8 @@ mod tests {
         let data = [3_i32, -2, 7];
         let copied = NdArray::<i32>::from_slice(&data).unwrap();
         assert_eq!(copied.buffer.to_vec::<i32>().unwrap(), data);
+
+        let shaped = NdArray::<i32>::from_shape_slice(&[1, 3], &data).unwrap();
+        assert_eq!(shaped.buffer.to_vec::<i32>().unwrap(), data);
     }
 }

--- a/crates/mohu-array/tests/array_tests.rs
+++ b/crates/mohu-array/tests/array_tests.rs
@@ -1,5 +1,6 @@
 use mohu_array::NdArray;
 use mohu_dtype::DType;
+use mohu_error::MohuError;
 
 #[test]
 fn zeros_metadata() {
@@ -26,6 +27,40 @@ fn from_slice_is_one_dimensional() {
     assert_eq!(a.ndim(), 1);
     assert_eq!(a.len(), 3);
     assert_eq!(a.dtype(), DType::I32);
+}
+
+#[test]
+fn from_shape_slice_preserves_shape_and_row_major_values() {
+    let a = NdArray::<f64>::from_shape_slice(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    assert_eq!(a.shape(), &[2, 3]);
+    assert_eq!(a.len(), 6);
+    assert_eq!(a.dtype(), DType::F64);
+}
+
+#[test]
+fn from_shape_slice_supports_scalar_and_zero_sized_shapes() {
+    let scalar = NdArray::<f64>::from_shape_slice(&[], &[3.0]).unwrap();
+    let scalar_shape: &[usize] = &[];
+    assert_eq!(scalar.shape(), scalar_shape);
+    assert_eq!(scalar.len(), 1);
+    assert!(!scalar.is_empty());
+
+    let empty = NdArray::<i32>::from_shape_slice(&[2, 0, 3], &[]).unwrap();
+    assert_eq!(empty.shape(), &[2, 0, 3]);
+    assert_eq!(empty.len(), 0);
+    assert!(empty.is_empty());
+}
+
+#[test]
+fn from_shape_slice_rejects_mismatch_and_overflow() {
+    let mismatch = NdArray::<i32>::from_shape_slice(&[3, 3], &[1, 2, 3, 4, 5, 6]);
+    assert!(matches!(
+        mismatch,
+        Err(MohuError::ReshapeIncompatible { .. })
+    ));
+
+    let overflow = NdArray::<u8>::from_shape_slice(&[usize::MAX, 2], &[]);
+    assert!(matches!(overflow, Err(MohuError::ShapeOverflow { .. })));
 }
 
 #[test]


### PR DESCRIPTION
Implements the smallest NdArray shaped-construction seam from #151. Adds `from_shape_slice(shape, data)` by composing Buffer construction and checked reshape, with scalar, zero-sized, mismatch, overflow, dtype, and row-major tests. Updates the crate README.

Refs #151; does not close umbrella #10.