### PR TITLE
feat(io): add typed homogeneous CSV reader

### DIFF
--- a/CRATE_MAP.md
+++ b/CRATE_MAP.md
@@ -286,11 +286,11 @@ Structured map of all workspace crates, their dependencies, modules, and public 
 | Module | Format |
 |--------|--------|
 | `npy` | `.npy` / `.npz` read/write |
-| `csv` | CSV import/export |
+| `csv` | Typed homogeneous CSV reading; writing remains planned |
 | `arrow` | Apache Arrow IPC interop |
 | `mmap` | memory-mapped file arrays |
 
-**Note**: Module source files are stubs.
+**Status**: Partial — typed homogeneous CSV reading is implemented; CSV writing and the other listed formats remain incomplete.
 
 ---
 
@@ -360,5 +360,5 @@ mohu-testing ──► mohu-error, mohu-dtype, mohu-buffer, approx, proptest
 | `mohu-stats` | Stubs only |
 | `mohu-sparse` | Stubs only |
 | `mohu-masked` | Stubs only |
-| `mohu-io` | Stubs only |
+| `mohu-io` | Partial — typed homogeneous CSV reading implemented; other I/O remains incomplete |
 | `mohu-testing` | Stubs only |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +757,7 @@ name = "mohu-io"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "csv",
  "memmap2",
  "mohu-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ half         = { version = "2.4", features = ["num-traits"] }
 num-traits   = "0.2"
 num-complex  = "0.4"
 num-integer  = "0.1"
+csv          = "1.3"
 
 # ── FFT ───────────────────────────────────────────────────────────────────────
 rustfft      = "6"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ if a crate says *stub*, its implementation modules contain no public implementat
 | `mohu-stats` | Descriptive statistics, hypothesis tests | ⬜ stub |
 | `mohu-sparse` | COO / CSR / CSC formats | ⬜ stub |
 | `mohu-masked` | Masked arrays, null propagation | ⬜ stub |
-| `mohu-io` | `.npy` / `.npz` / CSV / Arrow IPC / HDF5 / Parquet | ⬜ stub |
+| `mohu-io` | Typed homogeneous CSV reading; other I/O formats pending | ◐ partial |
 | `mohu-testing` | Fixtures, property strategies, array comparison | ⬜ stub |
 
 Companion repositories: [`mohu-compute`](https://github.com/mohu-org/mohu-compute)

--- a/crates/mohu-io/Cargo.toml
+++ b/crates/mohu-io/Cargo.toml
@@ -17,6 +17,7 @@ arrow.workspace       = true
 serde.workspace       = true
 memmap2.workspace     = true
 thiserror.workspace   = true
+csv.workspace         = true
 
 
 [package.metadata.cargo-machete]

--- a/crates/mohu-io/src/csv.rs
+++ b/crates/mohu-io/src/csv.rs
@@ -1,1 +1,200 @@
+//! Typed, homogeneous CSV input for [`mohu_core::mohu_array::NdArray`].
 
+use std::{fmt::Display, fs::File, path::Path, str::FromStr};
+
+use mohu_core::{
+    mohu_array::{MohuElement, NdArray},
+    mohu_error::{MohuError, MohuResult},
+};
+
+/// Options controlling typed CSV input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CsvReadOptions {
+    /// Single-byte field delimiter.
+    pub delimiter: u8,
+    /// Whether the first record is a header and should be skipped.
+    pub has_header: bool,
+}
+
+impl Default for CsvReadOptions {
+    fn default() -> Self {
+        Self {
+            delimiter: b',',
+            has_header: false,
+        }
+    }
+}
+
+/// Reads a rectangular, homogeneous CSV file into a typed 2-D array.
+///
+/// Dtype is explicit in `T`; v1 does not infer types, preserve header names,
+/// represent missing values, or write CSV files. The first record is treated
+/// as data unless `options.has_header` is set.
+pub fn read_csv<T, P>(path: P, options: CsvReadOptions) -> MohuResult<NdArray<T>>
+where
+    T: MohuElement + FromStr,
+    T::Err: Display,
+    P: AsRef<Path>,
+{
+    let file = File::open(path)?;
+    read_csv_reader(file, options)
+}
+
+fn read_csv_reader<T, R>(reader: R, options: CsvReadOptions) -> MohuResult<NdArray<T>>
+where
+    T: MohuElement + FromStr,
+    T::Err: Display,
+    R: std::io::Read,
+{
+    if options.delimiter == 0 {
+        return Err(csv_error(0, 0, "NUL is not a valid CSV delimiter"));
+    }
+
+    let mut csv_reader = csv::ReaderBuilder::new()
+        .delimiter(options.delimiter)
+        .has_headers(false)
+        .from_reader(reader);
+    let mut records = csv_reader.records();
+    let mut row = 0usize;
+    let ncols = if options.has_header {
+        let header = records
+            .next()
+            .ok_or_else(|| csv_error(0, 0, "CSV header is missing"))?
+            .map_err(|error| csv_error(0, 0, error.to_string()))?;
+        if header.is_empty() {
+            return Err(csv_error(0, 0, "CSV header has no columns"));
+        }
+        row = 1;
+        header.len()
+    } else {
+        let first = records
+            .next()
+            .ok_or_else(|| csv_error(0, 0, "CSV contains no records"))?
+            .map_err(|error| csv_error(0, 0, error.to_string()))?;
+        if first.is_empty() {
+            return Err(csv_error(0, 0, "CSV record has no columns"));
+        }
+        let ncols = first.len();
+        let mut values = parse_record::<T>(&first, row)?;
+        row += 1;
+        for record in records {
+            let record = record.map_err(|error| csv_error(row, 0, error.to_string()))?;
+            if record.len() != ncols {
+                return Err(csv_error(
+                    row,
+                    0,
+                    format!("expected {ncols} columns, got {}", record.len()),
+                ));
+            }
+            values.extend(parse_record::<T>(&record, row)?);
+            row += 1;
+        }
+        return NdArray::from_shape_slice(&[row, ncols], &values);
+    };
+
+    let mut values = Vec::new();
+    for record in records {
+        let record = record.map_err(|error| csv_error(row, 0, error.to_string()))?;
+        if record.len() != ncols {
+            return Err(csv_error(
+                row,
+                0,
+                format!("expected {ncols} columns, got {}", record.len()),
+            ));
+        }
+        values.extend(parse_record::<T>(&record, row)?);
+        row += 1;
+    }
+    NdArray::from_shape_slice(&[row - 1, ncols], &values)
+}
+
+fn parse_record<T>(record: &csv::StringRecord, row: usize) -> MohuResult<Vec<T>>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    record
+        .iter()
+        .enumerate()
+        .map(|(col, field)| {
+            field
+                .parse::<T>()
+                .map_err(|error| csv_error(row, col, error.to_string()))
+        })
+        .collect()
+}
+
+fn csv_error(row: usize, col: usize, detail: impl Into<String>) -> MohuError {
+    MohuError::CsvParseError {
+        row,
+        col,
+        detail: detail.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn reads_typed_rectangular_data() {
+        let array =
+            read_csv_reader::<i64, _>(Cursor::new("1,2\n-3,4\n"), CsvReadOptions::default())
+                .unwrap();
+        assert_eq!(array.shape(), &[2, 2]);
+        assert_eq!(array.dtype(), mohu_core::mohu_dtype::dtype::DType::I64);
+    }
+
+    #[test]
+    fn parses_values_in_row_major_order() {
+        let record = csv::StringRecord::from(vec!["1.5", "-2", "3"]);
+        let values = parse_record::<f32>(&record, 0).unwrap();
+        assert_eq!(values, vec![1.5, -2.0, 3.0]);
+    }
+
+    #[test]
+    fn supports_header_and_custom_delimiter() {
+        let array = read_csv_reader::<f32, _>(
+            Cursor::new("x;y\n1.5;2.5\n"),
+            CsvReadOptions {
+                delimiter: b';',
+                has_header: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(array.shape(), &[1, 2]);
+    }
+
+    #[test]
+    fn rejects_ragged_and_unparseable_records_with_context() {
+        let ragged = read_csv_reader::<i64, _>(Cursor::new("1,2\n3\n"), CsvReadOptions::default())
+            .err()
+            .expect("expected CSV error");
+        assert!(matches!(ragged, MohuError::CsvParseError { row: 1, .. }));
+        let bad = read_csv_reader::<i64, _>(Cursor::new("1,nope\n"), CsvReadOptions::default())
+            .err()
+            .expect("expected CSV error");
+        assert!(matches!(
+            bad,
+            MohuError::CsvParseError { row: 0, col: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn handles_empty_and_header_only_files() {
+        let empty = read_csv_reader::<i64, _>(Cursor::new(""), CsvReadOptions::default())
+            .err()
+            .expect("expected CSV error");
+        assert!(matches!(empty, MohuError::CsvParseError { .. }));
+        let header = read_csv_reader::<i64, _>(
+            Cursor::new("a,b,c\n"),
+            CsvReadOptions {
+                has_header: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(header.shape(), &[0, 3]);
+    }
+}


### PR DESCRIPTION
Adds narrow v1 CSV reading into `NdArray<T>` with explicit element type, parser-backed records, rectangularity checks, optional headers, custom delimiters, contextual parse errors, and empty/header-only handling.

Uses the existing NdArray shaped-construction seam. CSV writing, dtype inference, missing values, and heterogeneous tables remain deferred.

Refs #228; does not close it.