### PR TITLE
feat(array,io): add typed extraction and CSV output

### DIFF
--- a/CRATE_MAP.md
+++ b/CRATE_MAP.md
@@ -286,11 +286,11 @@ Structured map of all workspace crates, their dependencies, modules, and public 
 | Module | Format |
 |--------|--------|
 | `npy` | `.npy` / `.npz` read/write |
-| `csv` | Typed homogeneous CSV reading; writing remains planned |
+| `csv` | Typed homogeneous CSV reading and writing; other I/O remains planned |
 | `arrow` | Apache Arrow IPC interop |
 | `mmap` | memory-mapped file arrays |
 
-**Status**: Partial — typed homogeneous CSV reading is implemented; CSV writing and the other listed formats remain incomplete.
+**Status**: Partial — typed homogeneous CSV reading and writing are implemented; the other listed formats remain incomplete.
 
 ---
 
@@ -360,5 +360,5 @@ mohu-testing ──► mohu-error, mohu-dtype, mohu-buffer, approx, proptest
 | `mohu-stats` | Stubs only |
 | `mohu-sparse` | Stubs only |
 | `mohu-masked` | Stubs only |
-| `mohu-io` | Partial — typed homogeneous CSV reading implemented; other I/O remains incomplete |
+| `mohu-io` | Partial — typed homogeneous CSV reading and writing implemented; other I/O remains incomplete |
 | `mohu-testing` | Stubs only |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ if a crate says *stub*, its implementation modules contain no public implementat
 | `mohu-stats` | Descriptive statistics, hypothesis tests | ⬜ stub |
 | `mohu-sparse` | COO / CSR / CSC formats | ⬜ stub |
 | `mohu-masked` | Masked arrays, null propagation | ⬜ stub |
-| `mohu-io` | Typed homogeneous CSV reading; other I/O formats pending | ◐ partial |
+| `mohu-io` | Typed homogeneous CSV reading and writing; other I/O formats pending | ◐ partial |
 | `mohu-testing` | Fixtures, property strategies, array comparison | ⬜ stub |
 
 Companion repositories: [`mohu-compute`](https://github.com/mohu-org/mohu-compute)

--- a/crates/mohu-array/src/array.rs
+++ b/crates/mohu-array/src/array.rs
@@ -1,9 +1,9 @@
-use std::marker::PhantomData;
+use std::{convert::TryFrom, marker::PhantomData};
 
 use mohu_buffer::buffer::Buffer;
 use mohu_dtype::dtype::DType;
 use mohu_dtype::scalar::Scalar;
-use mohu_error::MohuResult;
+use mohu_error::{MohuError, MohuResult};
 
 /// Element types supported by [`NdArray`].
 pub trait MohuElement: Scalar {}
@@ -72,6 +72,38 @@ impl<T: MohuElement> NdArray<T> {
     /// Returns the runtime dtype of the backing buffer.
     pub fn dtype(&self) -> DType {
         self.buffer.dtype()
+    }
+
+    /// Copies the logical elements into a typed vector.
+    pub fn to_vec(&self) -> MohuResult<Vec<T>> {
+        self.buffer.to_vec::<T>()
+    }
+
+    /// Borrows the underlying buffer for read-only integration.
+    pub fn as_buffer(&self) -> &Buffer {
+        &self.buffer
+    }
+
+    /// Consumes the array and returns its underlying buffer without cloning.
+    pub fn into_buffer(self) -> Buffer {
+        self.buffer
+    }
+}
+
+impl<T: MohuElement> TryFrom<Buffer> for NdArray<T> {
+    type Error = MohuError;
+
+    fn try_from(buffer: Buffer) -> MohuResult<Self> {
+        if buffer.dtype() != T::DTYPE {
+            return Err(MohuError::DTypeMismatch {
+                expected: T::DTYPE.to_string(),
+                got: buffer.dtype().to_string(),
+            });
+        }
+        Ok(Self {
+            buffer,
+            _marker: PhantomData,
+        })
     }
 }
 

--- a/crates/mohu-array/tests/array_tests.rs
+++ b/crates/mohu-array/tests/array_tests.rs
@@ -1,4 +1,5 @@
 use mohu_array::NdArray;
+use mohu_buffer::Buffer;
 use mohu_dtype::DType;
 use mohu_error::MohuError;
 
@@ -89,4 +90,34 @@ fn all_supported_dtypes_report_runtime_type() {
         num_complex::Complex<f32> => DType::C64,
         num_complex::Complex<f64> => DType::C128,
     );
+}
+
+#[test]
+fn typed_extraction_and_buffer_interop_preserve_layout() {
+    let array = NdArray::<i32>::from_shape_slice(&[2, 3], &[1, 2, 3, 4, 5, 6]).unwrap();
+    assert_eq!(array.to_vec().unwrap(), vec![1, 2, 3, 4, 5, 6]);
+    assert_eq!(array.as_buffer().shape(), &[2, 3]);
+
+    let buffer = array.into_buffer();
+    let restored = NdArray::<i32>::try_from(buffer).unwrap();
+    assert_eq!(restored.to_vec().unwrap(), vec![1, 2, 3, 4, 5, 6]);
+}
+
+#[test]
+fn typed_interop_preserves_non_contiguous_logical_values() {
+    let view = Buffer::from_slice(&[1_i32, 2, 3, 4, 5, 6])
+        .unwrap()
+        .reshape(&[2, 3])
+        .unwrap()
+        .transpose();
+    let array = NdArray::<i32>::try_from(view).unwrap();
+    assert_eq!(array.shape(), &[3, 2]);
+    assert_eq!(array.to_vec().unwrap(), vec![1, 4, 2, 5, 3, 6]);
+}
+
+#[test]
+fn typed_interop_rejects_mismatched_dtype() {
+    let buffer = Buffer::zeros(DType::F64, &[1]).unwrap();
+    let result = NdArray::<i32>::try_from(buffer);
+    assert!(matches!(result, Err(MohuError::DTypeMismatch { .. })));
 }

--- a/crates/mohu-io/src/csv.rs
+++ b/crates/mohu-io/src/csv.rs
@@ -1,6 +1,6 @@
-//! Typed, homogeneous CSV input for [`mohu_core::mohu_array::NdArray`].
+//! Typed, homogeneous CSV input and output for [`mohu_core::mohu_array::NdArray`].
 
-use std::{fmt::Display, fs::File, path::Path, str::FromStr};
+use std::{fmt::Display, fs::File, io::Write, path::Path, str::FromStr};
 
 use mohu_core::{
     mohu_array::{MohuElement, NdArray},
@@ -132,6 +132,79 @@ fn csv_error(row: usize, col: usize, detail: impl Into<String>) -> MohuError {
     }
 }
 
+/// Options controlling typed CSV output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CsvWriteOptions {
+    /// Single-byte field delimiter.
+    pub delimiter: u8,
+}
+
+impl Default for CsvWriteOptions {
+    fn default() -> Self {
+        Self { delimiter: b',' }
+    }
+}
+
+/// Writes a two-dimensional homogeneous array as row-major CSV records.
+///
+/// Headers are not emitted because [`NdArray`] does not retain column names.
+/// Zero-row arrays are allowed; zero-column arrays and arrays with any other
+/// rank are rejected.
+pub fn write_csv<T, P>(path: P, array: &NdArray<T>, options: CsvWriteOptions) -> MohuResult<()>
+where
+    T: MohuElement + Display,
+    P: AsRef<Path>,
+{
+    let file = File::create(path)?;
+    write_csv_writer(file, array, options)
+}
+
+fn write_csv_writer<T, W>(writer: W, array: &NdArray<T>, options: CsvWriteOptions) -> MohuResult<()>
+where
+    T: MohuElement + Display,
+    W: Write,
+{
+    if array.ndim() != 2 {
+        return Err(MohuError::DimensionMismatch {
+            expected: 2,
+            got: array.ndim(),
+        });
+    }
+    let shape = array.shape();
+    if shape[1] == 0 {
+        return Err(MohuError::ZeroSizedDimension { axis: 1 });
+    }
+    if options.delimiter == 0 {
+        return Err(MohuError::CorruptData {
+            format: "CSV",
+            detail: "NUL is not a valid CSV delimiter".to_owned(),
+        });
+    }
+
+    let values = array.to_vec()?;
+    let mut csv_writer = csv::WriterBuilder::new()
+        .delimiter(options.delimiter)
+        .from_writer(writer);
+    for row in values.chunks_exact(shape[1]) {
+        let fields = row.iter().map(ToString::to_string).collect::<Vec<_>>();
+        csv_writer.write_record(fields).map_err(csv_write_error)?;
+    }
+    csv_writer
+        .into_inner()
+        .map(|_| ())
+        .map_err(|error| MohuError::Io(error.into_error()))
+}
+
+fn csv_write_error(error: csv::Error) -> MohuError {
+    match error.into_kind() {
+        csv::ErrorKind::Io(error) => MohuError::Io(error),
+        other => MohuError::CorruptData {
+            format: "CSV",
+            detail: format!("{other:?}"),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,5 +284,56 @@ mod tests {
         )
         .unwrap();
         assert_eq!(header.shape(), &[0, 3]);
+    }
+
+    #[test]
+    fn writes_rows_and_custom_delimiters() {
+        let array = NdArray::<i64>::from_shape_slice(&[2, 3], &[1, 2, 3, 4, 5, 6]).unwrap();
+        let mut output = Vec::new();
+        write_csv_writer(&mut output, &array, CsvWriteOptions::default()).unwrap();
+        assert_eq!(output, b"1,2,3\n4,5,6\n");
+
+        output.clear();
+        write_csv_writer(&mut output, &array, CsvWriteOptions { delimiter: b';' }).unwrap();
+        assert_eq!(output, b"1;2;3\n4;5;6\n");
+    }
+
+    #[test]
+    fn writes_non_contiguous_arrays_in_logical_order() {
+        let buffer = mohu_core::mohu_buffer::buffer::Buffer::from_slice(&[1_i32, 2, 3, 4, 5, 6])
+            .unwrap()
+            .reshape(&[2, 3])
+            .unwrap()
+            .transpose();
+
+        let array = NdArray::<i32>::try_from(buffer).unwrap();
+        let mut output = Vec::new();
+        write_csv_writer(&mut output, &array, CsvWriteOptions::default()).unwrap();
+        assert_eq!(output, b"1,4\n2,5\n3,6\n");
+    }
+
+    #[test]
+    fn rejects_unsupported_output_shapes() {
+        let one_dimensional = NdArray::<i64>::from_slice(&[1, 2]).unwrap();
+        assert!(matches!(
+            write_csv_writer(
+                &mut Vec::new(),
+                &one_dimensional,
+                CsvWriteOptions::default()
+            ),
+            Err(MohuError::DimensionMismatch {
+                expected: 2,
+                got: 1
+            })
+        ));
+        let zero_columns = NdArray::<i64>::zeros(&[2, 0]).unwrap();
+        assert!(matches!(
+            write_csv_writer(&mut Vec::new(), &zero_columns, CsvWriteOptions::default()),
+            Err(MohuError::ZeroSizedDimension { axis: 1 })
+        ));
+        let zero_rows = NdArray::<i64>::zeros(&[0, 2]).unwrap();
+        let mut output = Vec::new();
+        write_csv_writer(&mut output, &zero_rows, CsvWriteOptions::default()).unwrap();
+        assert!(output.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- add safe typed NdArray extraction and Buffer interop
- add homogeneous 2-D CSV writing with custom delimiters
- preserve logical order for non-contiguous arrays

## Scope
- `NdArray::to_vec`, `as_buffer`, `into_buffer`, and validated `TryFrom<Buffer>`
- `CsvWriteOptions` and `write_csv`
- no CSV headers, dtype inference, missing values, or writing for non-2-D arrays

Refs #10
Refs #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV writing for typed two-dimensional arrays, including configurable delimiters and support for non-contiguous data.
  * Added array conversion utilities for extracting typed values and accessing or transferring underlying buffers.
  * Added validation when converting buffers to typed arrays, including data-type mismatch errors.
* **Documentation**
  * Updated project documentation to reflect that typed CSV reading and writing are supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->