### PR TITLE
feat(special): add stable elementary helpers

### DIFF
--- a/crates/mohu-special/src/lib.rs
+++ b/crates/mohu-special/src/lib.rs
@@ -1,10 +1,9 @@
 pub mod bessel;
 /// Special mathematical functions for mohu.
 ///
-/// Equivalent to `scipy.special` — pure-Rust implementations with
-/// double-precision accuracy (< 1 ULP for most functions) and SIMD-ready
-/// scalar kernels that `mohu-ops` can vectorise.
-///
+/// The currently implemented surface is the stable elementary helper subset
+/// in [`misc`]. The remaining families are planned and are not yet equivalent
+/// to SciPy or covered by the long-term numerical accuracy target.
 /// # Function families
 ///
 /// | Module        | Functions                                              |
@@ -18,17 +17,15 @@ pub mod bessel;
 /// | [`stats_fn`]  | ndtr, ndtri, chdtr, fdtr, stdtr, gdtr (CDF/PPF)        |
 /// | [`misc`]      | log1p, expm1, logit, expit, xlogy, xlog1py             |
 ///
-/// # Accuracy targets
+/// # Implementation status
 ///
-/// All functions aim for < 5 ULP error on the standard IEEE double range.
-/// Where the underlying algorithm cannot achieve this, the docstring
-/// documents the actual error bound.
+/// Implemented: `misc::{log1p, expm1, logit, expit, xlogy, xlog1py}` using
+/// stable standard-library primitives where available.
 ///
-/// # Vectorisation
-///
-/// Every scalar function is `#[inline(always)]` and designed to auto-vectorise
-/// under LLVM.  `mohu-simd` provides hand-written AVX2 versions for the
-/// most common (erf, gamma, exp, log) on x86-64.
+/// Planned/incomplete: `erf`, `gamma`, `beta`, `bessel`, `expint`, `trig`, and
+/// distribution helpers. Future implementations require documented domain,
+/// pole, NaN/infinity behavior, reference vectors, boundary tests, and
+/// evidence before making ULP or SciPy-compatibility claims.
 pub mod beta;
 pub mod erf;
 pub mod expint;

--- a/crates/mohu-special/src/misc.rs
+++ b/crates/mohu-special/src/misc.rs
@@ -1,1 +1,122 @@
-// misc — implementation pending
+//! Stable elementary scalar helpers.
+
+/// Computes `ln(1 + x)` without losing precision for small `x`.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(mohu_special::misc::log1p(0.0), 0.0);
+/// ```
+#[inline]
+pub fn log1p(x: f64) -> f64 {
+    x.ln_1p()
+}
+
+/// Computes `exp(x) - 1` without losing precision for small `x`.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(mohu_special::misc::expm1(0.0), 0.0);
+/// ```
+#[inline]
+pub fn expm1(x: f64) -> f64 {
+    x.exp_m1()
+}
+
+/// Computes the logit function on the real unit interval.
+///
+/// Values outside `[0, 1]` produce `NaN`; endpoints produce signed infinities.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(mohu_special::misc::logit(0.5), 0.0);
+/// ```
+#[inline]
+pub fn logit(p: f64) -> f64 {
+    if !(0.0..=1.0).contains(&p) {
+        return f64::NAN;
+    }
+    p.ln() - (-p).ln_1p()
+}
+
+/// Computes the numerically stable logistic function.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(mohu_special::misc::expit(0.0), 0.5);
+/// ```
+#[inline]
+pub fn expit(x: f64) -> f64 {
+    if x >= 0.0 {
+        1.0 / (1.0 + (-x).exp())
+    } else {
+        let exp_x = x.exp();
+        exp_x / (1.0 + exp_x)
+    }
+}
+
+/// Computes `x * ln(y)`, defining `xlogy(0, y)` as zero.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(mohu_special::misc::xlogy(0.0, 0.0), 0.0);
+/// ```
+#[inline]
+pub fn xlogy(x: f64, y: f64) -> f64 {
+    if x == 0.0 { 0.0 } else { x * y.ln() }
+}
+
+/// Computes `x * ln(1 + y)`, defining `xlog1py(0, y)` as zero.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(mohu_special::misc::xlog1py(0.0, -1.0), 0.0);
+/// ```
+#[inline]
+pub fn xlog1py(x: f64, y: f64) -> f64 {
+    if x == 0.0 { 0.0 } else { x * y.ln_1p() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn stable_log_helpers_cover_boundaries() {
+        assert_eq!(log1p(0.0), 0.0);
+        assert_eq!(log1p(-0.0), -0.0);
+        assert!(log1p(-1.0).is_infinite());
+        assert!(log1p(-1.1).is_nan());
+        assert_eq!(expm1(0.0), 0.0);
+        assert_eq!(expm1(-0.0), -0.0);
+        assert_eq!(expm1(f64::NEG_INFINITY), -1.0);
+        assert!(expm1(f64::NAN).is_nan());
+    }
+    #[test]
+    fn logistic_and_logit_are_stable() {
+        assert_eq!(expit(0.0), 0.5);
+        assert_eq!(expit(f64::INFINITY), 1.0);
+        assert_eq!(expit(f64::NEG_INFINITY), 0.0);
+        assert!(expit(f64::NAN).is_nan());
+        assert_eq!(logit(0.0), f64::NEG_INFINITY);
+        assert_eq!(logit(1.0), f64::INFINITY);
+        assert!(logit(-0.1).is_nan());
+        assert!(logit(1.1).is_nan());
+        for x in [-10.0, -1.0, 0.0, 1.0, 10.0] {
+            assert!((logit(expit(x)) - x).abs() < 1e-12);
+        }
+    }
+    #[test]
+    fn xlog_helpers_preserve_zero_and_domains() {
+        assert_eq!(xlogy(0.0, 0.0), 0.0);
+        assert_eq!(xlog1py(0.0, -1.0), 0.0);
+        assert!(xlogy(1.0, -1.0).is_nan());
+        assert!(xlog1py(1.0, -1.1).is_nan());
+        assert!(xlogy(1.0, 0.0).is_infinite());
+        assert!(xlog1py(1.0, -1.0).is_infinite());
+    }
+}


### PR DESCRIPTION
## Summary
- implement stable log1p, expm1, logit, expit, xlogy, and xlog1py helpers
- add boundary and identity tests
- correct special-function documentation to distinguish implemented and planned families

Refs #222