### PR TITLE
feat(array): add typed immutable access

### DIFF
--- a/crates/mohu-array/README.md
+++ b/crates/mohu-array/README.md
@@ -26,7 +26,7 @@ Internal modules:
 
 ## Planned API Surface
 
-> **Status:** NdArray construction and introspection are implemented. Indexing, views, and arithmetic remain planned; signatures may change before stabilisation.
+> **Status:** NdArray construction, typed immutable access, and Buffer interop are implemented. Indexing, views, and arithmetic remain planned; signatures may change before stabilisation.
 > See the [issue tracker](https://github.com/mohu-org/mohu/issues?q=label%3A%22crate%3A+mohu-array%22) for progress.
 
 ### Construction
@@ -45,18 +45,18 @@ let c = NdArray::<i32>::from_slice(&[1, 2, 3, 4, 5, 6]); // 1-D
 let d = NdArray::<i32>::from_shape_slice(&[2, 3], &[1, 2, 3, 4, 5, 6]);
 ```
 
-### Indexing
+### Typed immutable access
 
 ```rust
-// Element access
-let val: f64 = a[[1, 2]];
+let a = NdArray::<i32>::from_shape_slice(&[2, 2], &[1, 2, 3, 4])?;
+assert_eq!(a.get(&[1, 0])?, 3);
 
-// Mutable element access
-a[[0, 0]] = 3.14;
-
-// Slicing — returns a zero-copy view
-let row = a.slice(s![0, ..]);
+let scalar = NdArray::<f64>::from_shape_slice(&[], &[3.14])?;
+assert_eq!(scalar.item()?, 3.14);
 ```
+
+Ergonomic indexing, mutation, and slicing are planned; `a[[0, 0]]` is not
+currently implemented.
 
 ### Arithmetic
 
@@ -84,7 +84,7 @@ let t = a.transpose();
 
 ## Status
 
-`mohu-array` is **under active development** and is not yet published to [crates.io](https://crates.io). Construction and metadata are implemented; indexing, views, and arithmetic remain incomplete. See the [issue tracker](https://github.com/mohu-org/mohu/issues?q=label%3A%22crate%3A+mohu-array%22).
+`mohu-array` is **under active development** and is not yet published to [crates.io](https://crates.io). Construction, metadata, typed immutable access, and Buffer interop are implemented; indexing, views, and arithmetic remain incomplete. See the [issue tracker](https://github.com/mohu-org/mohu/issues?q=label%3A%22crate%3A+mohu-array%22).
 
 Do not depend on this crate in production — public API stability is not guaranteed before the first versioned release.
 

--- a/crates/mohu-array/src/array.rs
+++ b/crates/mohu-array/src/array.rs
@@ -74,6 +74,35 @@ impl<T: MohuElement> NdArray<T> {
         self.buffer.dtype()
     }
 
+    /// Returns the element at `indices` using the array's compile-time type.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use mohu_array::NdArray;
+    /// let array = NdArray::<i32>::from_shape_slice(&[2, 2], &[1, 2, 3, 4])?;
+    /// assert_eq!(array.get(&[1, 0])?, 3);
+    /// # Ok::<(), mohu_error::MohuError>(())
+    /// ```
+    pub fn get(&self, indices: &[usize]) -> MohuResult<T> {
+        self.buffer.get::<T>(indices)
+    }
+
+    /// Extracts the sole logical element using the array's compile-time type.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use mohu_array::NdArray;
+    /// let scalar = NdArray::<f64>::from_shape_slice(&[], &[3.14])?;
+    /// assert_eq!(scalar.item()?, 3.14);
+    /// # Ok::<(), mohu_error::MohuError>(())
+    /// ```
+    #[must_use = "use the extracted item or handle the error"]
+    pub fn item(&self) -> MohuResult<T> {
+        self.buffer.item::<T>()
+    }
+
     /// Copies the logical elements into a typed vector.
     pub fn to_vec(&self) -> MohuResult<Vec<T>> {
         self.buffer.to_vec::<T>()

--- a/crates/mohu-array/tests/array_tests.rs
+++ b/crates/mohu-array/tests/array_tests.rs
@@ -121,3 +121,29 @@ fn typed_interop_rejects_mismatched_dtype() {
     let result = NdArray::<i32>::try_from(buffer);
     assert!(matches!(result, Err(MohuError::DTypeMismatch { .. })));
 }
+
+#[test]
+fn typed_immutable_access_handles_scalar_nd_and_non_contiguous_arrays() {
+    let array = NdArray::<i32>::from_shape_slice(&[2, 2], &[1, 2, 3, 4]).unwrap();
+    assert_eq!(array.get(&[1, 0]).unwrap(), 3);
+    assert!(matches!(
+        array.get(&[2, 0]),
+        Err(MohuError::IndexOutOfBounds { .. })
+    ));
+    assert!(array.get(&[0]).is_err());
+
+    let scalar = NdArray::<f64>::from_shape_slice(&[], &[3.125]).unwrap();
+    assert_eq!(scalar.get(&[]).unwrap().to_bits(), 3.125_f64.to_bits());
+    assert_eq!(scalar.item().unwrap().to_bits(), 3.125_f64.to_bits());
+
+    let view = Buffer::from_slice(&[1_i32, 2, 3, 4, 5, 6])
+        .unwrap()
+        .reshape(&[2, 3])
+        .unwrap()
+        .transpose();
+    let typed = NdArray::<i32>::try_from(view).unwrap();
+    assert_eq!(typed.get(&[2, 1]).unwrap(), 6);
+
+    let singleton = NdArray::<i32>::from_shape_slice(&[1, 1], &[9]).unwrap();
+    assert_eq!(singleton.item().unwrap(), 9);
+}

--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -807,6 +807,31 @@ impl Buffer {
         Ok(unsafe { ptr.read_unaligned() })
     }
 
+    /// Extracts the sole logical element as type `T`.
+    ///
+    /// This succeeds for any layout with exactly one element, including a
+    /// scalar shape and single-element strided views.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use mohu_buffer::Buffer;
+    /// let buffer = Buffer::from_slice(&[42_i32])?;
+    /// assert_eq!(buffer.item::<i32>()?, 42);
+    /// # Ok::<(), mohu_error::MohuError>(())
+    /// ```
+    #[must_use = "use the extracted item or handle the error"]
+    pub fn item<T: Scalar>(&self) -> MohuResult<T> {
+        if self.len() != 1 {
+            return Err(MohuError::domain(
+                "item",
+                format!("requires exactly one element, got {}", self.len()),
+            ));
+        }
+        let indices = vec![0; self.ndim()];
+        self.get::<T>(&indices)
+    }
+
     /// Sets the element at `indices` to `value`.
     pub fn set<T: Scalar>(&mut self, indices: &[usize], value: T) -> MohuResult<()> {
         if T::DTYPE != self.dtype {

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -761,3 +761,49 @@ fn allclose_contract_rejects_shape_and_non_float_inputs() {
         Err(mohu_error::MohuError::DomainError { .. })
     ));
 }
+
+#[test]
+fn item_supports_scalar_singleton_and_strided_views() {
+    let scalar = Buffer::from_slice(&[42_i32]).unwrap().reshape(&[]).unwrap();
+    assert_eq!(scalar.item::<i32>().unwrap(), 42);
+
+    let singleton = Buffer::from_slice(&[7.5_f64]).unwrap();
+    assert_eq!(
+        singleton.item::<f64>().unwrap().to_bits(),
+        7.5_f64.to_bits()
+    );
+
+    let view = Buffer::from_slice(&[10_i32, 20, 30])
+        .unwrap()
+        .slice_axis(
+            0,
+            SliceArg {
+                start: Some(1),
+                stop: Some(2),
+                step: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(view.item::<i32>().unwrap(), 20);
+}
+
+#[test]
+fn item_preserves_typed_and_cardinality_errors() {
+    let scalar = Buffer::from_slice(&[1_i32]).unwrap();
+    assert!(matches!(
+        scalar.item::<f64>(),
+        Err(MohuError::DTypeMismatch { .. })
+    ));
+
+    let empty = Buffer::zeros(DType::I32, &[0]).unwrap();
+    assert!(matches!(
+        empty.item::<i32>(),
+        Err(MohuError::DomainError { op: "item", .. })
+    ));
+
+    let many = Buffer::from_slice(&[1_i32, 2]).unwrap();
+    assert!(matches!(
+        many.item::<i32>(),
+        Err(MohuError::DomainError { op: "item", .. })
+    ));
+}


### PR DESCRIPTION
## Summary
- add Buffer::item() for any single logical element
- add typed NdArray::get() and NdArray::item()
- cover scalar, strided, dtype, bounds, and cardinality behavior
- update mohu-array current API documentation

Closes #40
Refs #10

This deliberately leaves mutation, Index/IndexMut, Deref, views, and Clone semantics for later API work.