### PR TITLE
fix(buffer): harden conditional selection

### DIFF
--- a/crates/mohu-buffer/src/buffer.rs
+++ b/crates/mohu-buffer/src/buffer.rs
@@ -649,6 +649,18 @@ impl Buffer {
     pub fn shape(&self) -> &[usize] {
         self.layout.shape()
     }
+    /// Returns `Ok(())` when two buffers have exactly equal shapes.
+    pub fn shape_matches(&self, other: &Buffer) -> MohuResult<()> {
+        if self.shape() == other.shape() {
+            Ok(())
+        } else {
+            Err(MohuError::ShapeMismatch {
+                expected: self.shape().to_vec(),
+                got: other.shape().to_vec(),
+            })
+        }
+    }
+
     /// Returns the byte strides of this buffer.
     #[inline]
     pub fn strides(&self) -> &[isize] {

--- a/crates/mohu-buffer/src/ops.rs
+++ b/crates/mohu-buffer/src/ops.rs
@@ -540,54 +540,24 @@ pub fn where_select<T: Scalar + Copy + Send + Sync>(
 
     if mask.dtype() != DType::U8 {
         return Err(MohuError::DTypeMismatch {
-            expected: "U8".to_string(),
+            expected: DType::U8.to_string(),
             got: mask.dtype().to_string(),
         });
     }
-    for (name, buf) in [("a", a), ("b", b)] {
-        if T::DTYPE != buf.dtype() {
-            return Err(MohuError::DTypeMismatch {
-                expected: T::DTYPE.to_string(),
-                got: buf.dtype().to_string(),
-            });
-        }
-        if buf.shape() != mask.shape() {
-            return Err(MohuError::ShapeMismatch {
-                expected: mask.shape().to_vec(),
-                got: buf.shape().to_vec(),
-            });
-        }
-        if !buf.is_c_contiguous() {
-            let _ = name;
-            return Err(MohuError::NonContiguous);
-        }
-    }
-    if !dst.is_writeable() {
-        return Err(MohuError::ReadOnly);
-    }
-    if dst.shape() != mask.shape() {
-        return Err(MohuError::ShapeMismatch {
-            expected: mask.shape().to_vec(),
-            got: dst.shape().to_vec(),
-        });
-    }
-    dst.make_unique()?;
+    mask.shape_matches(a)?;
+    mask.shape_matches(b)?;
+    mask.shape_matches(dst)?;
 
-    let len = mask.len();
-    let m_ptr = mask.as_ptr();
-    let a_ptr = a.as_ptr() as *const T;
-    let b_ptr = b.as_ptr() as *const T;
-    let d_ptr = unsafe { dst.as_mut_ptr() } as *mut T;
+    let mask_slice = mask.as_slice::<u8>()?;
+    let a_slice = a.as_slice::<T>()?;
+    let b_slice = b.as_slice::<T>()?;
+    let dst_slice = dst.as_mut_slice::<T>()?;
 
-    let m_s = unsafe { std::slice::from_raw_parts(m_ptr, len) };
-    let a_s = unsafe { std::slice::from_raw_parts(a_ptr, len) };
-    let b_s = unsafe { std::slice::from_raw_parts(b_ptr, len) };
-    let d_s = unsafe { std::slice::from_raw_parts_mut(d_ptr, len) };
-
-    m_s.par_iter()
-        .zip(a_s.par_iter())
-        .zip(b_s.par_iter())
-        .zip(d_s.par_iter_mut())
+    mask_slice
+        .par_iter()
+        .zip(a_slice.par_iter())
+        .zip(b_slice.par_iter())
+        .zip(dst_slice.par_iter_mut())
         .for_each(|(((m, av), bv), dv)| {
             *dv = if *m != 0 { *av } else { *bv };
         });

--- a/crates/mohu-buffer/tests/integration.rs
+++ b/crates/mohu-buffer/tests/integration.rs
@@ -807,3 +807,25 @@ fn item_preserves_typed_and_cardinality_errors() {
         Err(MohuError::DomainError { op: "item", .. })
     ));
 }
+
+#[test]
+fn shape_matches_requires_exact_shape() {
+    let a = Buffer::zeros(DType::I32, &[2, 3]).unwrap();
+    assert!(
+        a.shape_matches(&Buffer::zeros(DType::I32, &[2, 3]).unwrap())
+            .is_ok()
+    );
+    assert!(
+        matches!(a.shape_matches(&Buffer::zeros(DType::I32, &[3, 2]).unwrap()), Err(MohuError::ShapeMismatch { ref expected, ref got }) if expected == &[2, 3] && got == &[3, 2])
+    );
+    assert!(matches!(
+        a.shape_matches(&Buffer::zeros(DType::I32, &[6]).unwrap()),
+        Err(MohuError::ShapeMismatch { .. })
+    ));
+    assert!(
+        Buffer::zeros(DType::I32, &[])
+            .unwrap()
+            .shape_matches(&Buffer::zeros(DType::F64, &[]).unwrap())
+            .is_ok()
+    );
+}

--- a/crates/mohu-buffer/tests/where_select_tests.rs
+++ b/crates/mohu-buffer/tests/where_select_tests.rs
@@ -1,0 +1,73 @@
+use mohu_buffer::{Buffer, ops::where_select};
+use mohu_dtype::DType;
+use mohu_error::MohuError;
+#[test]
+fn basic_selection() {
+    let mask = Buffer::from_slice(&[1u8, 0, 1]).unwrap();
+    let a = Buffer::from_slice(&[10i32, 20, 30]).unwrap();
+    let b = Buffer::from_slice(&[1i32, 2, 3]).unwrap();
+    let mut d = Buffer::zeros(DType::I32, &[3]).unwrap();
+    where_select::<i32>(&mask, &a, &b, &mut d).unwrap();
+    assert_eq!(d.as_slice::<i32>().unwrap(), &[10, 2, 30]);
+}
+#[test]
+fn empty_and_2d_selection() {
+    let m = Buffer::from_slice(&[1u8, 0, 0, 1])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let a = Buffer::from_slice(&[10i32, 20, 30, 40])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let b = Buffer::from_slice(&[1i32, 2, 3, 4])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let mut d = Buffer::zeros(DType::I32, &[2, 2]).unwrap();
+    where_select::<i32>(&m, &a, &b, &mut d).unwrap();
+    assert_eq!(d.as_slice::<i32>().unwrap(), &[10, 2, 3, 40]);
+    let m = Buffer::zeros(DType::U8, &[0]).unwrap();
+    let a = Buffer::zeros(DType::I32, &[0]).unwrap();
+    let b = Buffer::zeros(DType::I32, &[0]).unwrap();
+    let mut d = Buffer::zeros(DType::I32, &[0]).unwrap();
+    where_select::<i32>(&m, &a, &b, &mut d).unwrap();
+}
+#[test]
+fn rejects_shape_and_wrong_dst_dtype() {
+    let m = Buffer::from_slice(&[1u8, 0]).unwrap();
+    let a = Buffer::from_slice(&[1i32, 2]).unwrap();
+    let b = Buffer::from_slice(&[3i32]).unwrap();
+    let mut d = Buffer::zeros(DType::I32, &[2]).unwrap();
+    assert!(matches!(
+        where_select::<i32>(&m, &a, &b, &mut d),
+        Err(MohuError::ShapeMismatch { .. })
+    ));
+    let mut d = Buffer::zeros(DType::F64, &[2]).unwrap();
+    let b = Buffer::from_slice(&[3i32, 4]).unwrap();
+    assert!(matches!(
+        where_select::<i32>(&m, &a, &b, &mut d),
+        Err(MohuError::DTypeMismatch { .. })
+    ));
+}
+#[test]
+fn rejects_noncontiguous_mask() {
+    let m = Buffer::from_slice(&[1u8, 0, 1, 0])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap()
+        .transpose();
+    let a = Buffer::from_slice(&[1i32, 2, 3, 4])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let b = Buffer::from_slice(&[5i32, 6, 7, 8])
+        .unwrap()
+        .reshape(&[2, 2])
+        .unwrap();
+    let mut d = Buffer::zeros(DType::I32, &[2, 2]).unwrap();
+    assert!(matches!(
+        where_select::<i32>(&m, &a, &b, &mut d),
+        Err(MohuError::NonContiguous)
+    ));
+}


### PR DESCRIPTION
Implements #43 and #62.

- Adds exact-shape validation through Buffer::shape_matches.
- Replaces where_select raw pointer slices with validated typed Buffer slices.
- Preserves the U8-mask contract and adds dtype, shape, empty, and non-contiguous coverage.

Closes #43
Closes #62