### PR TITLE
feat(demo): add college Rust showcase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mohu-demo"
+version = "0.1.0"
+dependencies = [
+ "mohu-array",
+ "mohu-buffer",
+ "mohu-ops",
+ "mohu-random",
+]
+
+[[package]]
 name = "mohu-dtype"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,21 @@
+[package]
+name        = "mohu-demo"
+version     = "0.1.0"
+edition     = "2024"
+rust-version = "1.85"
+publish     = false
+autoexamples = false
+
+[dependencies]
+mohu-array  = { workspace = true }
+mohu-buffer = { workspace = true }
+mohu-ops    = { workspace = true }
+mohu-random = { workspace = true }
+
+[[example]]
+name = "college_demo"
+path = "examples/college_demo.rs"
+
 [workspace]
 members = [
     # ── Foundation layer (order = dependency depth) ──────────────────────────

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,34 @@
+# MOHU College Demo
+
+## Run
+
+From the repository root:
+
+```bash
+cargo run --release --example college_demo
+```
+
+Run twice from a clean terminal. The command has no network or external-data dependency.
+
+## What the demo proves
+
+1. **Array construction** — `NdArray<f64>` accepts typed row-major data and exposes values, shape, rank, and runtime dtype.
+2. **Views and strides** — reshape and transpose preserve logical values; transpose shares backing storage and changes strides instead of copying.
+3. **Broadcasting** — a `[3]` row becomes a `[2, 3]` read-only view with a zero stride on the repeated axis.
+4. **Matrix multiplication** — `mohu-ops::matmul` computes the documented 2×2 result through the public `Buffer` semantic API.
+5. **Seeded randomness** — equal seeds produce equal integer buffers.
+
+## 30-second explanation
+
+“MOHU already has a typed Rust array layer backed by a reference-counted buffer. Metadata is explicit, layout transformations are views, broadcasting uses zero strides, matrix multiplication has a tested public semantic owner in `mohu-ops`, and seeded generation is reproducible. These are narrow working foundations, not claims of NumPy completeness.”
+
+## Validation
+
+The shown behavior is covered by existing `mohu-array`, `mohu-buffer`, `mohu-ops`, and `mohu-random` tests. The executable also asserts the matrix result and seeded reproducibility.
+
+## Prototype limits
+
+- Rust demo is the guaranteed path.
+- FFT currently supports complex C64/C128 `fft`/`ifft`; real and multidimensional helpers remain incomplete.
+- Python bindings are a separate prototype and are not required for this backup demo.
+- No performance, NumPy compatibility, or full API-completeness claim is made.

--- a/examples/college_demo.rs
+++ b/examples/college_demo.rs
@@ -1,0 +1,69 @@
+use mohu_array::NdArray;
+use mohu_buffer::Buffer;
+use mohu_ops::matmul::matmul;
+use mohu_random::Rng;
+
+fn main() -> mohu_buffer::MohuResult<()> {
+    println!("============================================================");
+    println!("MOHU — RUST-POWERED NUMERICAL ARRAYS");
+    println!("============================================================");
+
+    println!("\n1. ARRAY CONSTRUCTION");
+    let array = NdArray::<f64>::from_shape_slice(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0])?;
+    println!("values  = {:?}", array.to_vec()?);
+    println!("shape   = {:?}", array.shape());
+    println!("ndim    = {}", array.ndim());
+    println!("dtype   = {}", array.dtype());
+
+    println!("\n2. VIEWS & STRIDES");
+    let source = Buffer::from_slice(&[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?.reshape(&[2, 3])?;
+    let reshaped = source.reshape(&[3, 2])?;
+    let transposed = source.transpose();
+    println!(
+        "reshape  shape={:?} values={:?}",
+        reshaped.shape(),
+        reshaped.to_vec::<f64>()?
+    );
+    println!(
+        "transpose shape={:?} strides={:?}",
+        transposed.shape(),
+        transposed.strides()
+    );
+    println!("transpose values={:?}", transposed.to_vec::<f64>()?);
+    println!("zero-copy backing storage = {}", transposed.is_shared());
+
+    println!("\n3. BROADCASTING");
+    let row = Buffer::from_slice(&[10.0_f64, 20.0, 30.0])?;
+    let broadcast = row.broadcast_to(&[2, 3])?;
+    println!("shape   = {:?}", broadcast.shape());
+    println!(
+        "strides = {:?} (0 means repeated view)",
+        broadcast.strides()
+    );
+    println!("values  = {:?}", broadcast.to_vec::<f64>()?);
+
+    println!("\n4. MATRIX MULTIPLICATION");
+    let lhs = Buffer::from_slice(&[1.0_f64, 2.0, 3.0, 4.0])?.reshape(&[2, 2])?;
+    let rhs = Buffer::from_slice(&[5.0_f64, 6.0, 7.0, 8.0])?.reshape(&[2, 2])?;
+    let product = matmul(&lhs, &rhs)?;
+    println!("[[1, 2], [3, 4]] @ [[5, 6], [7, 8]]");
+    println!("result  = {:?}", product.to_vec::<f64>()?);
+    assert_eq!(product.to_vec::<f64>()?, vec![19.0, 22.0, 43.0, 50.0]);
+
+    println!("\n5. SEEDED RANDOMNESS");
+    let mut first = Rng::new(42);
+    let mut second = Rng::new(42);
+    let first_values = first.integers(&[4], 0, 10)?;
+    let second_values = second.integers(&[4], 0, 10)?;
+    assert_eq!(
+        first_values.to_vec::<i64>()?,
+        second_values.to_vec::<i64>()?
+    );
+    println!("seed 42 values = {:?}", first_values.to_vec::<i64>()?);
+    println!("same seed reproducible = true");
+
+    println!("\n============================================================");
+    println!("DEMO COMPLETE — tested Buffer, views, broadcasting, matmul, RNG");
+    println!("============================================================");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add runnable cargo run --release --example college_demo showcase
- demonstrate typed arrays, views/strides, broadcasting, Buffer-facing matmul, and seeded RNG
- add concise DEMO.md with commands, claims, validation, and limits

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- cargo doc --workspace --no-deps --all-features
- make ci
- cargo run --release --example college_demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runnable MOHU College demonstration covering array construction, reshaping, transposition, broadcasting, matrix multiplication, and seeded random number generation.
  * The demo displays results and validates matrix multiplication and deterministic random output.

* **Documentation**
  * Added setup and usage instructions for running the demonstration in release mode.
  * Documented the demonstrated capabilities, testing coverage, and current prototype limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->